### PR TITLE
Fix SBSA Boot

### DIFF
--- a/Platforms/QemuSbsaPkg/Override/ArmPkg/Library/StandaloneMmCoreEntryPoint/Arm/CreateHobList.c
+++ b/Platforms/QemuSbsaPkg/Override/ArmPkg/Library/StandaloneMmCoreEntryPoint/Arm/CreateHobList.c
@@ -1,0 +1,190 @@
+/** @file
+  Creates HOB during Standalone MM Foundation entry point
+  on ARM platforms.
+
+Copyright (c) 2017 - 2021, Arm Ltd. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiMm.h>
+
+#include <PiPei.h>
+#include <Guid/MmramMemoryReserve.h>
+#include <Guid/MpInformation.h>
+
+#include <Library/ArmStandaloneMmCoreEntryPoint.h>
+#include <Library/ArmMmuLib.h>
+#include <Library/ArmSvcLib.h>
+#include <Library/DebugLib.h>
+#include <Library/HobLib.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/SerialPortLib.h>
+
+#include <IndustryStandard/ArmStdSmc.h>
+
+#include "StandaloneMmCoreEntryPoint.h"
+
+extern EFI_HOB_HANDOFF_INFO_TABLE *
+HobConstructor (
+  IN VOID   *EfiMemoryBegin,
+  IN UINTN  EfiMemoryLength,
+  IN VOID   *EfiFreeMemoryBottom,
+  IN VOID   *EfiFreeMemoryTop
+  );
+
+// GUID to identify HOB with whereabouts of communication buffer with Normal
+// World
+extern EFI_GUID  gEfiStandaloneMmNonSecureBufferGuid;
+
+/**
+  Use the boot information passed by privileged firmware to populate a HOB list
+  suitable for consumption by the MM Core and drivers.
+
+  @param  [in, out] CpuDriverEntryPoint   Address of MM CPU driver entrypoint
+  @param  [in]      PayloadBootInfo       Boot information passed by privileged
+                                          firmware
+
+**/
+VOID *
+CreateHobListFromBootInfo (
+  IN       EFI_SECURE_PARTITION_BOOT_INFO  *PayloadBootInfo
+  )
+{
+  EFI_HOB_HANDOFF_INFO_TABLE      *HobStart;
+  EFI_RESOURCE_ATTRIBUTE_TYPE     Attributes;
+  UINT32                          Index;
+  UINT32                          BufferSize;
+  UINT32                          Flags;
+  EFI_MMRAM_HOB_DESCRIPTOR_BLOCK  *MmramRangesHob;
+  EFI_MMRAM_DESCRIPTOR            *MmramRanges;
+  EFI_MMRAM_DESCRIPTOR            *NsCommBufMmramRange;
+  MP_INFORMATION_HOB_DATA         *MpInformationHobData;
+  EFI_PROCESSOR_INFORMATION       *ProcInfoBuffer;
+  EFI_SECURE_PARTITION_CPU_INFO   *CpuInfo;
+
+  // Create a hoblist with a PHIT and EOH
+  HobStart = HobConstructor (
+               (VOID *)(UINTN)PayloadBootInfo->SpMemBase,
+               (UINTN)PayloadBootInfo->SpMemLimit - PayloadBootInfo->SpMemBase,
+               (VOID *)(UINTN)PayloadBootInfo->SpHeapBase,
+               (VOID *)(UINTN)(PayloadBootInfo->SpHeapBase + PayloadBootInfo->SpHeapSize)
+               );
+
+  // Check that the Hoblist starts at the bottom of the Heap
+  ASSERT (HobStart == (VOID *)(UINTN)PayloadBootInfo->SpHeapBase);
+
+  // Build a Boot Firmware Volume HOB
+  BuildFvHob (PayloadBootInfo->SpImageBase, PayloadBootInfo->SpImageSize);
+
+  // Build a resource descriptor Hob that describes the available physical
+  // memory range
+  Attributes = (
+                EFI_RESOURCE_ATTRIBUTE_PRESENT |
+                EFI_RESOURCE_ATTRIBUTE_INITIALIZED |
+                EFI_RESOURCE_ATTRIBUTE_TESTED |
+                EFI_RESOURCE_ATTRIBUTE_UNCACHEABLE |
+                EFI_RESOURCE_ATTRIBUTE_WRITE_COMBINEABLE |
+                EFI_RESOURCE_ATTRIBUTE_WRITE_THROUGH_CACHEABLE |
+                EFI_RESOURCE_ATTRIBUTE_WRITE_BACK_CACHEABLE
+                );
+
+  BuildResourceDescriptorHob (
+    EFI_RESOURCE_SYSTEM_MEMORY,
+    Attributes,
+    (UINTN)PayloadBootInfo->SpMemBase,
+    PayloadBootInfo->SpMemLimit - PayloadBootInfo->SpMemBase
+    );
+
+  // Find the size of the GUIDed HOB with MP information
+  BufferSize  = sizeof (MP_INFORMATION_HOB_DATA);
+  BufferSize += sizeof (EFI_PROCESSOR_INFORMATION) * PayloadBootInfo->NumCpus;
+
+  // Create a Guided MP information HOB to enable the ARM TF CPU driver to
+  // perform per-cpu allocations.
+  MpInformationHobData = BuildGuidHob (&gMpInformationHobGuid, BufferSize);
+
+  // Populate the MP information HOB with the topology information passed by
+  // privileged firmware
+  MpInformationHobData->NumberOfProcessors        = PayloadBootInfo->NumCpus;
+  MpInformationHobData->NumberOfEnabledProcessors = PayloadBootInfo->NumCpus;
+  ProcInfoBuffer                                  = MpInformationHobData->ProcessorInfoBuffer;
+  CpuInfo                                         = PayloadBootInfo->CpuInfo;
+
+  for (Index = 0; Index < PayloadBootInfo->NumCpus; Index++) {
+    ProcInfoBuffer[Index].ProcessorId      = CpuInfo[Index].Mpidr;
+    ProcInfoBuffer[Index].Location.Package = GET_CLUSTER_ID (CpuInfo[Index].Mpidr);
+    ProcInfoBuffer[Index].Location.Core    = GET_CORE_ID (CpuInfo[Index].Mpidr);
+    ProcInfoBuffer[Index].Location.Thread  = GET_CORE_ID (CpuInfo[Index].Mpidr);
+
+    Flags = PROCESSOR_ENABLED_BIT | PROCESSOR_HEALTH_STATUS_BIT;
+    if (CpuInfo[Index].Flags & CPU_INFO_FLAG_PRIMARY_CPU) {
+      Flags |= PROCESSOR_AS_BSP_BIT;
+    }
+
+    ProcInfoBuffer[Index].StatusFlag = Flags;
+  }
+
+  // Create a Guided HOB to tell the ARM TF CPU driver the location and length
+  // of the communication buffer shared with the Normal world.
+  NsCommBufMmramRange = (EFI_MMRAM_DESCRIPTOR *)BuildGuidHob (
+                                                  &gEfiStandaloneMmNonSecureBufferGuid,
+                                                  sizeof (EFI_MMRAM_DESCRIPTOR)
+                                                  );
+  NsCommBufMmramRange->PhysicalStart = PayloadBootInfo->SpNsCommBufBase;
+  NsCommBufMmramRange->CpuStart      = PayloadBootInfo->SpNsCommBufBase;
+  NsCommBufMmramRange->PhysicalSize  = PayloadBootInfo->SpNsCommBufSize;
+  NsCommBufMmramRange->RegionState   = EFI_CACHEABLE | EFI_ALLOCATED;
+
+  // Find the size of the GUIDed HOB with SRAM ranges
+  BufferSize  = sizeof (EFI_MMRAM_HOB_DESCRIPTOR_BLOCK);
+  BufferSize += PayloadBootInfo->NumSpMemRegions * sizeof (EFI_MMRAM_DESCRIPTOR);
+
+  // Create a GUIDed HOB with SRAM ranges
+  MmramRangesHob = BuildGuidHob (&gEfiMmPeiMmramMemoryReserveGuid, BufferSize);
+
+  // Fill up the number of MMRAM memory regions
+  MmramRangesHob->NumberOfMmReservedRegions = PayloadBootInfo->NumSpMemRegions;
+  // Fill up the MMRAM ranges
+  MmramRanges = &MmramRangesHob->Descriptor[0];
+
+  // Base and size of memory occupied by the Standalone MM image
+  MmramRanges[0].PhysicalStart = PayloadBootInfo->SpImageBase;
+  MmramRanges[0].CpuStart      = PayloadBootInfo->SpImageBase;
+  MmramRanges[0].PhysicalSize  = PayloadBootInfo->SpImageSize;
+  MmramRanges[0].RegionState   = EFI_CACHEABLE | EFI_ALLOCATED;
+
+  // Base and size of buffer shared with privileged Secure world software
+  MmramRanges[1].PhysicalStart = PayloadBootInfo->SpSharedBufBase;
+  MmramRanges[1].CpuStart      = PayloadBootInfo->SpSharedBufBase;
+  MmramRanges[1].PhysicalSize  = PayloadBootInfo->SpSharedBufSize;
+  MmramRanges[1].RegionState   = EFI_CACHEABLE | EFI_ALLOCATED;
+
+  // Base and size of buffer used for synchronous communication with Normal
+  // world software
+  MmramRanges[2].PhysicalStart = PayloadBootInfo->SpNsCommBufBase;
+  MmramRanges[2].CpuStart      = PayloadBootInfo->SpNsCommBufBase;
+  MmramRanges[2].PhysicalSize  = PayloadBootInfo->SpNsCommBufSize;
+  MmramRanges[2].RegionState   = EFI_CACHEABLE | EFI_ALLOCATED;
+
+  // Base and size of memory allocated for stacks for all cpus
+  MmramRanges[3].PhysicalStart = PayloadBootInfo->SpStackBase;
+  MmramRanges[3].CpuStart      = PayloadBootInfo->SpStackBase;
+  MmramRanges[3].PhysicalSize  = PayloadBootInfo->SpPcpuStackSize * PayloadBootInfo->NumCpus;
+  MmramRanges[3].RegionState   = EFI_CACHEABLE | EFI_ALLOCATED;
+
+  // Base and size of heap memory shared by all cpus
+  MmramRanges[4].PhysicalStart = (EFI_PHYSICAL_ADDRESS)(UINTN)HobStart;
+  MmramRanges[4].CpuStart      = (EFI_PHYSICAL_ADDRESS)(UINTN)HobStart;
+  MmramRanges[4].PhysicalSize  = HobStart->EfiFreeMemoryBottom - (EFI_PHYSICAL_ADDRESS)(UINTN)HobStart;
+  MmramRanges[4].RegionState   = EFI_CACHEABLE | EFI_ALLOCATED;
+
+  // Base and size of heap memory shared by all cpus
+  MmramRanges[5].PhysicalStart = HobStart->EfiFreeMemoryBottom;
+  MmramRanges[5].CpuStart      = HobStart->EfiFreeMemoryBottom;
+  MmramRanges[5].PhysicalSize  = HobStart->EfiFreeMemoryTop - HobStart->EfiFreeMemoryBottom;
+  MmramRanges[5].RegionState   = EFI_CACHEABLE;
+
+  return HobStart;
+}

--- a/Platforms/QemuSbsaPkg/Override/ArmPkg/Library/StandaloneMmCoreEntryPoint/Arm/SetPermissions.c
+++ b/Platforms/QemuSbsaPkg/Override/ArmPkg/Library/StandaloneMmCoreEntryPoint/Arm/SetPermissions.c
@@ -1,0 +1,385 @@
+/** @file
+  Locate, get and update PE/COFF permissions during Standalone MM
+  Foundation Entry point on ARM platforms.
+
+Copyright (c) 2017 - 2021, Arm Ltd. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiMm.h>
+
+#include <PiPei.h>
+#include <Guid/MmramMemoryReserve.h>
+#include <Guid/MpInformation.h>
+
+#include <Library/ArmStandaloneMmCoreEntryPoint.h>
+#include <Library/ArmMmuLib.h>
+#include <Library/ArmSvcLib.h>
+#include <Library/DebugLib.h>
+#include <Library/HobLib.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/SerialPortLib.h>
+
+#include <IndustryStandard/ArmStdSmc.h>
+
+#include "StandaloneMmCoreEntryPoint.h"
+
+/**
+  Privileged firmware assigns RO & Executable attributes to all memory occupied
+  by the Boot Firmware Volume. This function sets the correct permissions of
+  sections in the Standalone MM Core module to be able to access RO and RW data
+  and make further progress in the boot process.
+
+  @param  [in] ImageContext           Pointer to PE/COFF image context
+  @param  [in] ImageBase              Base of image in memory
+  @param  [in] SectionHeaderOffset    Offset of PE/COFF image section header
+  @param  [in] NumberOfSections       Number of Sections
+  @param  [in] TextUpdater            Function to change code permissions
+  @param  [in] ReadOnlyUpdater        Function to change RO permissions
+  @param  [in] ReadWriteUpdater       Function to change RW permissions
+
+**/
+EFI_STATUS
+EFIAPI
+UpdateMmFoundationPeCoffPermissions (
+  IN  CONST PE_COFF_LOADER_IMAGE_CONTEXT  *ImageContext,
+  IN  EFI_PHYSICAL_ADDRESS                ImageBase,
+  IN  UINT32                              SectionHeaderOffset,
+  IN  CONST  UINT16                       NumberOfSections,
+  IN  REGION_PERMISSION_UPDATE_FUNC       TextUpdater,
+  IN  REGION_PERMISSION_UPDATE_FUNC       ReadOnlyUpdater,
+  IN  REGION_PERMISSION_UPDATE_FUNC       ReadWriteUpdater
+  )
+{
+  EFI_IMAGE_SECTION_HEADER  SectionHeader;
+  RETURN_STATUS             Status;
+  EFI_PHYSICAL_ADDRESS      Base;
+  UINTN                     Size;
+  UINTN                     ReadSize;
+  UINTN                     Index;
+
+  ASSERT (ImageContext != NULL);
+
+  //
+  // Iterate over the sections
+  //
+  for (Index = 0; Index < NumberOfSections; Index++) {
+    //
+    // Read section header from file
+    //
+    Size     = sizeof (EFI_IMAGE_SECTION_HEADER);
+    ReadSize = Size;
+    Status   = ImageContext->ImageRead (
+                               ImageContext->Handle,
+                               SectionHeaderOffset,
+                               &Size,
+                               &SectionHeader
+                               );
+
+    if (RETURN_ERROR (Status) || (Size != ReadSize)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "%a: ImageContext->ImageRead () failed (Status = %r)\n",
+        __func__,
+        Status
+        ));
+      return Status;
+    }
+
+    DEBUG ((
+      DEBUG_INFO,
+      "%a: Section %d of image at 0x%lx has 0x%x permissions\n",
+      __func__,
+      Index,
+      ImageContext->ImageAddress,
+      SectionHeader.Characteristics
+      ));
+    DEBUG ((
+      DEBUG_INFO,
+      "%a: Section %d of image at 0x%lx has %a name\n",
+      __func__,
+      Index,
+      ImageContext->ImageAddress,
+      SectionHeader.Name
+      ));
+    DEBUG ((
+      DEBUG_INFO,
+      "%a: Section %d of image at 0x%lx has 0x%x address\n",
+      __func__,
+      Index,
+      ImageContext->ImageAddress,
+      ImageContext->ImageAddress + SectionHeader.VirtualAddress
+      ));
+    DEBUG ((
+      DEBUG_INFO,
+      "%a: Section %d of image at 0x%lx has 0x%x data\n",
+      __func__,
+      Index,
+      ImageContext->ImageAddress,
+      SectionHeader.PointerToRawData
+      ));
+
+    //
+    // If the section is marked as XN then remove the X attribute. Furthermore,
+    // if it is a writeable section then mark it appropriately as well.
+    //
+    if ((SectionHeader.Characteristics & EFI_IMAGE_SCN_MEM_EXECUTE) == 0) {
+      Base = ImageBase + SectionHeader.VirtualAddress;
+
+      TextUpdater (Base, SectionHeader.Misc.VirtualSize);
+
+      if ((SectionHeader.Characteristics & EFI_IMAGE_SCN_MEM_WRITE) != 0) {
+        ReadWriteUpdater (Base, SectionHeader.Misc.VirtualSize);
+        DEBUG ((
+          DEBUG_INFO,
+          "%a: Mapping section %d of image at 0x%lx with RW-XN permissions\n",
+          __func__,
+          Index,
+          ImageContext->ImageAddress
+          ));
+      } else {
+        DEBUG ((
+          DEBUG_INFO,
+          "%a: Mapping section %d of image at 0x%lx with RO-XN permissions\n",
+          __func__,
+          Index,
+          ImageContext->ImageAddress
+          ));
+      }
+    } else {
+      DEBUG ((
+        DEBUG_INFO,
+        "%a: Ignoring section %d of image at 0x%lx with 0x%x permissions\n",
+        __func__,
+        Index,
+        ImageContext->ImageAddress,
+        SectionHeader.Characteristics
+        ));
+    }
+
+    SectionHeaderOffset += sizeof (EFI_IMAGE_SECTION_HEADER);
+  }
+
+  return RETURN_SUCCESS;
+}
+
+/**
+  Privileged firmware assigns RO & Executable attributes to all memory occupied
+  by the Boot Firmware Volume. This function locates the Standalone MM Core
+  module PE/COFF image in the BFV and returns this information.
+
+  @param  [in]      BfvAddress         Base Address of Boot Firmware Volume
+  @param  [in, out] TeData             Pointer to address for allocating memory
+                                       for PE/COFF image data
+  @param  [in, out] TeDataSize         Pointer to size of PE/COFF image data
+
+**/
+EFI_STATUS
+EFIAPI
+LocateStandaloneMmCorePeCoffData (
+  IN        EFI_FIRMWARE_VOLUME_HEADER  *BfvAddress,
+  IN  OUT   VOID                        **TeData,
+  IN  OUT   UINTN                       *TeDataSize
+  )
+{
+  EFI_FFS_FILE_HEADER  *FileHeader;
+  EFI_STATUS           Status;
+
+  FileHeader = NULL;
+  Status     = FfsFindNextFile (
+                 EFI_FV_FILETYPE_SECURITY_CORE,
+                 BfvAddress,
+                 &FileHeader
+                 );
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "Unable to locate Standalone MM FFS file - 0x%x\n",
+      Status
+      ));
+    return Status;
+  }
+
+  Status = FfsFindSectionData (EFI_SECTION_PE32, FileHeader, TeData, TeDataSize);
+  if (EFI_ERROR (Status)) {
+    Status = FfsFindSectionData (EFI_SECTION_TE, FileHeader, TeData, TeDataSize);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "Unable to locate Standalone MM Section data - %r\n",
+        Status
+        ));
+      return Status;
+    }
+  }
+
+  DEBUG ((DEBUG_INFO, "Found Standalone MM PE data - 0x%x\n", *TeData));
+  return Status;
+}
+
+/**
+  Returns the PC COFF section information.
+
+  @param  [in, out] ImageContext         Pointer to PE/COFF image context
+  @param  [out]     ImageBase            Base of image in memory
+  @param  [out]     SectionHeaderOffset  Offset of PE/COFF image section header
+  @param  [out]     NumberOfSections     Number of Sections
+
+**/
+STATIC
+EFI_STATUS
+GetPeCoffSectionInformation (
+  IN  OUT   PE_COFF_LOADER_IMAGE_CONTEXT  *ImageContext,
+  OUT   EFI_PHYSICAL_ADDRESS              *ImageBase,
+  OUT   UINT32                            *SectionHeaderOffset,
+  OUT   UINT16                            *NumberOfSections
+  )
+{
+  RETURN_STATUS                        Status;
+  EFI_IMAGE_OPTIONAL_HEADER_PTR_UNION  Hdr;
+  EFI_IMAGE_OPTIONAL_HEADER_UNION      HdrData;
+  UINTN                                Size;
+  UINTN                                ReadSize;
+
+  ASSERT (ImageContext != NULL);
+  ASSERT (SectionHeaderOffset != NULL);
+  ASSERT (NumberOfSections != NULL);
+
+  Status = PeCoffLoaderGetImageInfo (ImageContext);
+  if (RETURN_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: PeCoffLoaderGetImageInfo () failed (Status == %r)\n",
+      __func__,
+      Status
+      ));
+    return Status;
+  }
+
+  if (ImageContext->SectionAlignment < EFI_PAGE_SIZE) {
+    //
+    // The sections need to be at least 4 KB aligned, since that is the
+    // granularity at which we can tighten permissions.
+    //
+    if (!ImageContext->IsTeImage) {
+      DEBUG ((
+        DEBUG_WARN,
+        "%a: non-TE Image at 0x%lx has SectionAlignment < 4 KB (%lu)\n",
+        __func__,
+        ImageContext->ImageAddress,
+        ImageContext->SectionAlignment
+        ));
+      return RETURN_UNSUPPORTED;
+    }
+
+    ImageContext->SectionAlignment = EFI_PAGE_SIZE;
+  }
+
+  //
+  // Read the PE/COFF Header. For PE32 (32-bit) this will read in too much
+  // data, but that should not hurt anything. Hdr.Pe32->OptionalHeader.Magic
+  // determines if this is a PE32 or PE32+ image. The magic is in the same
+  // location in both images.
+  //
+  Hdr.Union = &HdrData;
+  Size      = sizeof (EFI_IMAGE_OPTIONAL_HEADER_UNION);
+  ReadSize  = Size;
+  Status    = ImageContext->ImageRead (
+                              ImageContext->Handle,
+                              ImageContext->PeCoffHeaderOffset,
+                              &Size,
+                              Hdr.Pe32
+                              );
+
+  if (RETURN_ERROR (Status) || (Size != ReadSize)) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "%a: TmpContext->ImageRead () failed (Status = %r)\n",
+      __func__,
+      Status
+      ));
+    return Status;
+  }
+
+  *ImageBase = ImageContext->ImageAddress;
+  if (!ImageContext->IsTeImage) {
+    ASSERT (Hdr.Pe32->Signature == EFI_IMAGE_NT_SIGNATURE);
+
+    *SectionHeaderOffset = ImageContext->PeCoffHeaderOffset + sizeof (UINT32) +
+                           sizeof (EFI_IMAGE_FILE_HEADER);
+    *NumberOfSections = Hdr.Pe32->FileHeader.NumberOfSections;
+
+    switch (Hdr.Pe32->OptionalHeader.Magic) {
+      case EFI_IMAGE_NT_OPTIONAL_HDR32_MAGIC:
+        *SectionHeaderOffset += Hdr.Pe32->FileHeader.SizeOfOptionalHeader;
+        break;
+      case EFI_IMAGE_NT_OPTIONAL_HDR64_MAGIC:
+        *SectionHeaderOffset += Hdr.Pe32Plus->FileHeader.SizeOfOptionalHeader;
+        break;
+      default:
+        ASSERT (FALSE);
+    }
+  } else {
+    *SectionHeaderOffset = (UINTN)(sizeof (EFI_TE_IMAGE_HEADER));
+    *NumberOfSections    = Hdr.Te->NumberOfSections;
+    *ImageBase          -= (UINT32)Hdr.Te->StrippedSize - sizeof (EFI_TE_IMAGE_HEADER);
+  }
+
+  return RETURN_SUCCESS;
+}
+
+/**
+  Privileged firmware assigns RO & Executable attributes to all memory occupied
+  by the Boot Firmware Volume. This function locates the section information of
+  the Standalone MM Core module to be able to change permissions of the
+  individual sections later in the boot process.
+
+  @param  [in]      TeData                Pointer to PE/COFF image data
+  @param  [in, out] ImageContext          Pointer to PE/COFF image context
+  @param  [out]     ImageBase             Pointer to ImageBase variable
+  @param  [in, out] SectionHeaderOffset   Offset of PE/COFF image section header
+  @param  [in, out] NumberOfSections      Number of Sections
+
+**/
+EFI_STATUS
+EFIAPI
+GetStandaloneMmCorePeCoffSections (
+  IN        VOID                          *TeData,
+  IN  OUT   PE_COFF_LOADER_IMAGE_CONTEXT  *ImageContext,
+  OUT   EFI_PHYSICAL_ADDRESS              *ImageBase,
+  IN  OUT   UINT32                        *SectionHeaderOffset,
+  IN  OUT   UINT16                        *NumberOfSections
+  )
+{
+  EFI_STATUS  Status;
+
+  // Initialize the Image Context
+  ZeroMem (ImageContext, sizeof (PE_COFF_LOADER_IMAGE_CONTEXT));
+  ImageContext->Handle    = TeData;
+  ImageContext->ImageRead = PeCoffLoaderImageReadFromMemory;
+
+  DEBUG ((DEBUG_INFO, "Found Standalone MM PE data - 0x%x\n", TeData));
+
+  Status = GetPeCoffSectionInformation (
+             ImageContext,
+             ImageBase,
+             SectionHeaderOffset,
+             NumberOfSections
+             );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Unable to locate Standalone MM Core PE-COFF Section information - %r\n", Status));
+    return Status;
+  }
+
+  DEBUG ((
+    DEBUG_INFO,
+    "Standalone MM Core PE-COFF SectionHeaderOffset - 0x%x, NumberOfSections - %d\n",
+    *SectionHeaderOffset,
+    *NumberOfSections
+    ));
+
+  return Status;
+}

--- a/Platforms/QemuSbsaPkg/Override/ArmPkg/Library/StandaloneMmCoreEntryPoint/Arm/StandaloneMmCoreEntryPoint.c
+++ b/Platforms/QemuSbsaPkg/Override/ArmPkg/Library/StandaloneMmCoreEntryPoint/Arm/StandaloneMmCoreEntryPoint.c
@@ -1,0 +1,903 @@
+/** @file
+  Entry point to the Standalone MM Foundation when initialized during the SEC
+  phase on ARM platforms
+
+Copyright (c) 2017 - 2021, Arm Ltd. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiMm.h>
+
+#include <PiPei.h>
+#include <Guid/MmramMemoryReserve.h>
+#include <Guid/MpInformation.h>
+
+#include <Library/ArmStandaloneMmCoreEntryPoint.h>
+#include <Library/ArmSvcLib.h>
+#include <Library/DebugLib.h>
+#include <Library/HobLib.h>
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/SerialPortLib.h>
+#include <Library/ArmStandaloneMmMmuLib.h>
+#include <Library/PcdLib.h>
+
+#include <IndustryStandard/ArmStdSmc.h>
+#include <IndustryStandard/ArmMmSvc.h>
+#include <IndustryStandard/ArmFfaSvc.h>
+
+#include <Protocol/MmCommunication.h>
+#include <Protocol/PiMmCpuDriverEp.h>
+
+#include "StandaloneMmCoreEntryPoint.h"
+
+extern EFI_MM_SYSTEM_TABLE  gMmCoreMmst;
+
+#define BOOT_PAYLOAD_VERSION  1
+
+extern VOID  *gHobList;
+
+STATIC MISC_MM_COMMUNICATE_BUFFER   *mMiscMmCommunicateBuffer = NULL;
+STATIC EFI_MMRAM_DESCRIPTOR        *mNsCommBuffer            = NULL;
+STATIC EFI_MMRAM_DESCRIPTOR        *mSCommBuffer             = NULL;
+
+/**
+  Get communication ABI protocol.
+
+  @param  [out]   CommProtocol       Communication protocol.
+
+  @retval         EFI_SUCCESS
+  @retval         EFI_UNSUPPORTED    Not supported
+
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+GetCommProtocol (
+  OUT COMM_PROTOCOL  *CommProtocol
+  )
+{
+  EFI_STATUS    Status;
+  UINT16        RequestMajorVersion;
+  UINT16        RequestMinorVersion;
+  UINT16        CurrentMajorVersion;
+  UINT16        CurrentMinorVersion;
+  ARM_SVC_ARGS  SvcArgs;
+
+  RequestMajorVersion = ARM_FFA_MAJOR_VERSION;
+  RequestMinorVersion = ARM_FFA_MINOR_VERSION;
+
+  Status = ArmFfaLibGetVersion (
+             RequestMajorVersion,
+             RequestMinorVersion,
+             &CurrentMajorVersion,
+             &CurrentMinorVersion
+             );
+  if (!EFI_ERROR (Status)) {
+    *CommProtocol = CommProtocolFfa;
+  } else {
+    ZeroMem (&SvcArgs, sizeof (ARM_SVC_ARGS));
+    SvcArgs.Arg0 = ARM_FID_SPM_MM_VERSION_AARCH32;
+
+    ArmCallSvc (&SvcArgs);
+
+    if (SvcArgs.Arg0 == ARM_SPM_MM_RET_NOT_SUPPORTED) {
+      *CommProtocol = CommProtocolUnknown;
+      return EFI_UNSUPPORTED;
+    }
+
+    *CommProtocol       = CommProtocolSpmMm;
+    RequestMajorVersion = ARM_SPM_MM_SUPPORT_MAJOR_VERSION;
+    RequestMinorVersion = ARM_SPM_MM_SUPPORT_MINOR_VERSION;
+    CurrentMajorVersion =
+      ((SvcArgs.Arg0 >> ARM_SPM_MM_MAJOR_VERSION_SHIFT) & ARM_SPM_MM_VERSION_MASK);
+    CurrentMinorVersion =
+      ((SvcArgs.Arg0 >> ARM_SPM_MM_MINOR_VERSION_SHIFT) & ARM_SPM_MM_VERSION_MASK);
+  }
+
+  // Different major revision values indicate possibly incompatible functions.
+  // For two revisions, A and B, for which the major revision values are
+  // identical, if the minor revision value of revision B is greater than
+  // the minor revision value of revision A, then every function in
+  // revision A must work in a compatible way with revision B.
+  // However, it is possible for revision B to have a higher
+  // function count than revision A
+  if ((RequestMajorVersion != CurrentMajorVersion) ||
+      (RequestMinorVersion > CurrentMinorVersion))
+  {
+    DEBUG ((
+      DEBUG_INFO,
+      "Incompatible %s Versions.\n" \
+      "Request Version: Major=0x%x, Minor>=0x%x.\n" \
+      "Current Version: Major=0x%x, Minor=0x%x.\n",
+      (*CommProtocol == CommProtocolFfa) ? L"FF-A" : L"SPM_MM",
+      RequestMajorVersion,
+      RequestMinorVersion,
+      CurrentMajorVersion,
+      CurrentMinorVersion
+      ));
+
+    return EFI_UNSUPPORTED;
+  }
+
+  DEBUG ((
+    DEBUG_INFO,
+    "%s Version: Major=0x%x, Minor=0x%x\n",
+    (*CommProtocol == CommProtocolFfa) ? L"FF-A" : L"SPM_MM",
+    CurrentMajorVersion,
+    CurrentMinorVersion
+    ));
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Retrieve a pointer to and print the boot information passed by privileged
+  secure firmware.
+
+  @param  [in] SharedBufAddress   The pointer memory shared with privileged
+                                  firmware.
+
+**/
+EFI_SECURE_PARTITION_BOOT_INFO *
+GetAndPrintBootinformation (
+  IN VOID  *SharedBufAddress
+  )
+{
+  EFI_SECURE_PARTITION_BOOT_INFO  *PayloadBootInfo;
+  EFI_SECURE_PARTITION_CPU_INFO   *PayloadCpuInfo;
+  UINTN                           Index;
+
+  PayloadBootInfo = (EFI_SECURE_PARTITION_BOOT_INFO *)SharedBufAddress;
+
+  if (PayloadBootInfo == NULL) {
+    DEBUG ((DEBUG_ERROR, "PayloadBootInfo NULL\n"));
+    return NULL;
+  }
+
+  if (PayloadBootInfo->Header.Version != BOOT_PAYLOAD_VERSION) {
+    DEBUG ((
+      DEBUG_ERROR,
+      "Boot Information Version Mismatch. Current=0x%x, Expected=0x%x.\n",
+      PayloadBootInfo->Header.Version,
+      BOOT_PAYLOAD_VERSION
+      ));
+    return NULL;
+  }
+
+  DEBUG ((DEBUG_INFO, "NumSpMemRegions - 0x%x\n", PayloadBootInfo->NumSpMemRegions));
+  DEBUG ((DEBUG_INFO, "SpMemBase       - 0x%lx\n", PayloadBootInfo->SpMemBase));
+  DEBUG ((DEBUG_INFO, "SpMemLimit      - 0x%lx\n", PayloadBootInfo->SpMemLimit));
+  DEBUG ((DEBUG_INFO, "SpImageBase     - 0x%lx\n", PayloadBootInfo->SpImageBase));
+  DEBUG ((DEBUG_INFO, "SpStackBase     - 0x%lx\n", PayloadBootInfo->SpStackBase));
+  DEBUG ((DEBUG_INFO, "SpHeapBase      - 0x%lx\n", PayloadBootInfo->SpHeapBase));
+  DEBUG ((DEBUG_INFO, "SpNsCommBufBase - 0x%lx\n", PayloadBootInfo->SpNsCommBufBase));
+  DEBUG ((DEBUG_INFO, "SpSharedBufBase - 0x%lx\n", PayloadBootInfo->SpSharedBufBase));
+
+  DEBUG ((DEBUG_INFO, "SpImageSize     - 0x%x\n", PayloadBootInfo->SpImageSize));
+  DEBUG ((DEBUG_INFO, "SpPcpuStackSize - 0x%x\n", PayloadBootInfo->SpPcpuStackSize));
+  DEBUG ((DEBUG_INFO, "SpHeapSize      - 0x%x\n", PayloadBootInfo->SpHeapSize));
+  DEBUG ((DEBUG_INFO, "SpNsCommBufSize - 0x%x\n", PayloadBootInfo->SpNsCommBufSize));
+  DEBUG ((DEBUG_INFO, "SpSharedBufSize - 0x%x\n", PayloadBootInfo->SpSharedBufSize));
+
+  DEBUG ((DEBUG_INFO, "NumCpus         - 0x%x\n", PayloadBootInfo->NumCpus));
+  DEBUG ((DEBUG_INFO, "CpuInfo         - 0x%p\n", PayloadBootInfo->CpuInfo));
+
+  PayloadCpuInfo = (EFI_SECURE_PARTITION_CPU_INFO *)PayloadBootInfo->CpuInfo;
+
+  if (PayloadCpuInfo == NULL) {
+    DEBUG ((DEBUG_ERROR, "PayloadCpuInfo NULL\n"));
+    return NULL;
+  }
+
+  for (Index = 0; Index < PayloadBootInfo->NumCpus; Index++) {
+    DEBUG ((DEBUG_INFO, "Mpidr           - 0x%lx\n", PayloadCpuInfo[Index].Mpidr));
+    DEBUG ((DEBUG_INFO, "LinearId        - 0x%x\n", PayloadCpuInfo[Index].LinearId));
+    DEBUG ((DEBUG_INFO, "Flags           - 0x%x\n", PayloadCpuInfo[Index].Flags));
+  }
+
+  return PayloadBootInfo;
+}
+
+/**
+  Get service type.
+  When using FF-A ABI, there're ways to request service to StandaloneMm
+      - FF-A with MmCommunication protocol.
+      - FF-A service with each specification.
+   MmCommunication Protocol can use FFA_MSG_SEND_DIRECT_REQ or REQ2,
+   Other FF-A services should use FFA_MSG_SEND_DIRECT_REQ2.
+   In case of FF-A with MmCommunication protocol via FFA_MSG_SEND_DIRECT_REQ,
+   register x3 saves Communication Buffer with gEfiMmCommunication2ProtocolGuid.
+   In case of FF-A with MmCommunication protocol via FFA_MSG_SEND_DIRECT_REQ2,
+   register x2/x3 save gEfiMmCommunication2ProtocolGuid and
+   register x4 saves Communication Buffer with Service Guid.
+
+   Other FF-A services (ServiceTypeMisc) delivers register values according to
+   there own service specification.
+   That means it doesn't use MmCommunication Buffer with MmCommunication Header
+   format.
+   (i.e) Tpm service via FF-A or Firmware Update service via FF-A.
+   To support latter services by StandaloneMm, it defines SERVICE_TYPE_MISC.
+   So that StandaloneMmEntryPointCore.c generates MmCommunication Header
+   with delivered register values to dispatch service provided StandaloneMmCore.
+   So that service handler can get proper information from delivered register.
+
+   In case of SPM_MM Abi, it only supports MmCommunication service.
+
+
+  @param[in]      ServiceGuid                   Service Guid
+
+  @retval         ServiceTypeMmCommunication    Mm communication service
+  @retval         ServiceTypeMisc               Service via implemented defined
+                                                register ABI.
+                                                This will generate internal
+                                                MmCommunication Header
+                                                to dispatch service implemented
+                                                in standaloneMm
+  @retval         ServiceTypeUnknown            Not supported service.
+
+**/
+STATIC
+SERVICE_TYPE
+EFIAPI
+GetServiceType (
+  IN EFI_GUID  *ServiceGuid
+  )
+{
+  if (CompareGuid (ServiceGuid, &gEfiMmCommunication2ProtocolGuid)) {
+    return ServiceTypeMmCommunication;
+  }
+
+  return ServiceTypeMisc;
+}
+
+/**
+  Perform bounds check for the Ns and Secure Communication buffer.
+
+  NOTE: We do not need to validate the Misc Communication buffer as
+  we are initialising that in StandaloneMm.
+
+  @param  [in] CommBufferAddr   Address of the common buffer.
+
+  @retval   EFI_SUCCESS             Success.
+  @retval   EFI_ACCESS_DENIED       Access not permitted.
+**/
+STATIC
+EFI_STATUS
+ValidateMmCommBufferAddr (
+  IN UINTN  CommBufferAddr
+  )
+{
+  UINT64  NsCommBufferEnd;
+  UINT64  SCommBufferEnd;
+  UINT64  CommBufferEnd;
+  UINT64  CommBufferRange;
+
+  NsCommBufferEnd = mNsCommBuffer->PhysicalStart + mNsCommBuffer->PhysicalSize;
+  SCommBufferEnd  = mSCommBuffer->PhysicalStart + mSCommBuffer->PhysicalSize;
+
+  if ((CommBufferAddr >= mNsCommBuffer->PhysicalStart) &&
+      (CommBufferAddr < NsCommBufferEnd))
+  {
+    CommBufferEnd = NsCommBufferEnd;
+  } else if ((CommBufferAddr >= mSCommBuffer->PhysicalStart) &&
+             (CommBufferAddr < SCommBufferEnd))
+  {
+    CommBufferEnd = SCommBufferEnd;
+  } else {
+    return EFI_ACCESS_DENIED;
+  }
+
+  CommBufferRange = CommBufferEnd - CommBufferAddr;
+
+  if (CommBufferRange < sizeof (EFI_MM_COMMUNICATE_HEADER)) {
+    return EFI_ACCESS_DENIED;
+  }
+
+  // perform bounds check.
+  if (((CommBufferAddr + sizeof (EFI_MM_COMMUNICATE_HEADER) +
+        ((EFI_MM_COMMUNICATE_HEADER *)CommBufferAddr)->MessageLength)) >
+      CommBufferEnd)
+  {
+    return EFI_ACCESS_DENIED;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Convert EFI_STATUS to MM SPM return code.
+
+  @param [in] Status          edk2 status code.
+
+  @retval ARM_SPM_MM_RET_*    return value correspond to EFI_STATUS.
+
+**/
+STATIC
+UINTN
+EFIAPI
+EfiStatusToSpmMmStatus (
+  IN EFI_STATUS  Status
+  )
+{
+  switch (Status) {
+    case EFI_SUCCESS:
+      return ARM_SPM_MM_RET_SUCCESS;
+    case EFI_INVALID_PARAMETER:
+      return ARM_SPM_MM_RET_INVALID_PARAMS;
+    case EFI_ACCESS_DENIED:
+      return ARM_SPM_MM_RET_DENIED;
+    case EFI_OUT_OF_RESOURCES:
+      return ARM_SPM_MM_RET_NO_MEMORY;
+    default:
+      return ARM_SPM_MM_RET_NOT_SUPPORTED;
+  }
+}
+
+/**
+  Set svc arguments to report initialization status of StandaloneMm.
+
+  @param[in]      CommProtocol              ABI Protocol.
+  @param[in]      Status                    Result of initializing StandaloneMm.
+  @param[out]     EventCompleteSvcArgs      Args structure.
+
+**/
+STATIC
+VOID
+ReturnInitStatusToSpmc (
+  IN COMM_PROTOCOL  CommProtocol,
+  IN EFI_STATUS     Status,
+  OUT ARM_SVC_ARGS  *EventCompleteSvcArgs
+  )
+{
+  ZeroMem (EventCompleteSvcArgs, sizeof (ARM_SVC_ARGS));
+
+  if (CommProtocol == CommProtocolFfa) {
+    if (EFI_ERROR (Status)) {
+      EventCompleteSvcArgs->Arg0 = ARM_FID_FFA_ERROR;
+
+      /*
+       * In case SvcConduit, this must be zero.
+       */
+      EventCompleteSvcArgs->Arg1 = 0x00;
+      EventCompleteSvcArgs->Arg2 = EfiStatusToFfaStatus (Status);
+    } else {
+      /*
+       * For completion of initialization, It should use FFA_MSG_WAIT.
+       * See FF-A specification 5.5 Protocol for completing execution context
+       * initialization
+       */
+      EventCompleteSvcArgs->Arg0 = ARM_FID_FFA_WAIT;
+    }
+  } else if (CommProtocol == CommProtocolSpmMm) {
+    EventCompleteSvcArgs->Arg0 = ARM_FID_SPM_MM_SP_EVENT_COMPLETE;
+    EventCompleteSvcArgs->Arg1 = EfiStatusToSpmMmStatus (Status);
+  } else {
+    /*
+     * We don't know what communication abi protocol is using.
+     * Set Arg0 as MAX_UINTN to make SPMC know it's error situation.
+     */
+    EventCompleteSvcArgs->Arg0 = MAX_UINTN;
+  }
+}
+
+/**
+  Set Event Complete arguments to be returned via SVC call.
+
+  @param[in]      CommProtocol              Communication Protocol.
+  @param[in]      CommData                  Communication Abi specific data.
+  @param[in]      Status                    Result of StandaloneMm service.
+  @param[out]     EventCompleteSvcArgs      Args structure.
+
+**/
+STATIC
+VOID
+SetEventCompleteSvcArgs (
+  IN COMM_PROTOCOL  CommProtocol,
+  IN VOID           *CommData,
+  IN EFI_STATUS     Status,
+  OUT ARM_SVC_ARGS  *EventCompleteSvcArgs
+  )
+{
+  FFA_MSG_INFO  *FfaMsgInfo;
+
+  ZeroMem (EventCompleteSvcArgs, sizeof (ARM_SVC_ARGS));
+
+  if (CommProtocol == CommProtocolFfa) {
+    FfaMsgInfo = CommData;
+
+    if (EFI_ERROR (Status)) {
+      EventCompleteSvcArgs->Arg0 = ARM_FID_FFA_ERROR;
+
+      /*
+       * StandaloneMm is secure instance. So set as 0x00.
+       */
+      EventCompleteSvcArgs->Arg1 = 0x00;
+      EventCompleteSvcArgs->Arg2 = EfiStatusToFfaStatus (Status);
+    } else {
+      if (FfaMsgInfo->DirectMsgVersion == DirectMsgV1) {
+        EventCompleteSvcArgs->Arg0 = ARM_FID_FFA_MSG_SEND_DIRECT_RESP;
+        EventCompleteSvcArgs->Arg3 = ARM_FID_SPM_MM_SP_EVENT_COMPLETE;
+      } else {
+        EventCompleteSvcArgs->Arg0 = ARM_FID_FFA_MSG_SEND_DIRECT_RESP2;
+
+        if (FfaMsgInfo->ServiceType == ServiceTypeMisc) {
+          EventCompleteSvcArgs->Arg4 = mMiscMmCommunicateBuffer->DirectMsgArgs.Arg0;
+          EventCompleteSvcArgs->Arg5 = mMiscMmCommunicateBuffer->DirectMsgArgs.Arg1;
+          EventCompleteSvcArgs->Arg6 = mMiscMmCommunicateBuffer->DirectMsgArgs.Arg2;
+          EventCompleteSvcArgs->Arg7 = mMiscMmCommunicateBuffer->DirectMsgArgs.Arg3;
+        }
+      }
+
+      /*
+       * Swap source & dest partition id.
+       */
+      EventCompleteSvcArgs->Arg1 = PACK_PARTITION_ID_INFO (
+                                     FfaMsgInfo->DestPartId,
+                                     FfaMsgInfo->SourcePartId
+                                     );
+    }
+  } else {
+    EventCompleteSvcArgs->Arg0 = ARM_FID_SPM_MM_SP_EVENT_COMPLETE;
+    EventCompleteSvcArgs->Arg1 = EfiStatusToSpmMmStatus (Status);
+  }
+}
+
+/**
+  Wrap Misc service buffer with MmCommunication Header to
+  patch event handler via MmCommunication protocol.
+
+  @param[in]      EventSvcArgs              Passed arguments
+  @param[in]      ServiceGuid               Service Guid
+  @param[out]     Buffer                    Misc service data
+                                            wrapped with MmCommunication Header.
+
+**/
+STATIC
+VOID
+InitializeMiscMmCommunicateBuffer (
+  IN ARM_SVC_ARGS                 *EventSvcArgs,
+  IN EFI_GUID                     *ServiceGuid,
+  OUT MISC_MM_COMMUNICATE_BUFFER  *Buffer
+  )
+{
+  ZeroMem (Buffer, sizeof (MISC_MM_COMMUNICATE_BUFFER));
+
+  Buffer->MessageLength       = sizeof (DIRECT_MSG_ARGS);
+  Buffer->DirectMsgArgs.Arg0  = EventSvcArgs->Arg4;
+  Buffer->DirectMsgArgs.Arg1  = EventSvcArgs->Arg5;
+  Buffer->DirectMsgArgs.Arg2  = EventSvcArgs->Arg6;
+  Buffer->DirectMsgArgs.Arg3  = EventSvcArgs->Arg7;
+  CopyGuid (&Buffer->HeaderGuid, ServiceGuid);
+}
+
+/**
+  Convert UUID to EFI_GUID format.
+  for example, If there is EFI_GUID named
+  "378daedc-f06b-4446-8314-40ab933c87a3",
+
+  EFI_GUID is saved in memory like:
+     dc ae 8d 37
+     6b f0 46 44
+     83 14 40 ab
+     93 3c 87 a3
+
+  However, UUID should be saved like:
+     37 8d ae dc
+     f0 6b 44 46
+     83 14 40 ab
+     93 3c 87 a3
+
+  FF-A and other software components (i.e. linux-kernel)
+  uses below format.
+
+  To patch mm-service properly, the passed uuid should be converted to
+  EFI_GUID format.
+
+  @param [in]  Uuid            Uuid
+  @param [out] Guid            EFI_GUID
+
+**/
+STATIC
+VOID
+EFIAPI
+ConvertUuidToEfiGuid (
+  IN  UINT64    *Uuid,
+  OUT EFI_GUID  *Guid
+  )
+{
+  UINT32  *Data32;
+  UINT16  *Data16;
+
+  Data32    = (UINT32 *)Uuid;
+  Data32[0] = SwapBytes32 (Data32[0]);
+  Data16    = (UINT16 *)&Data32[1];
+  Data16[0] = SwapBytes16 (Data16[0]);
+  Data16[1] = SwapBytes16 (Data16[1]);
+  CopyGuid (Guid, (EFI_GUID *)Uuid);
+}
+
+/**
+  A loop to delegate events from SPMC.
+  DelegatedEventLoop() calls ArmCallSvc() to exit to SPMC.
+  When an event is delegated to StandaloneMm the SPMC returns control
+  to StandaloneMm by returning from the SVC call.
+
+  @param  [in] CommProtocol            Abi Protocol.
+  @param  [in] CpuDriverEntryPoint    Entry point to handle request.
+  @param  [in] EventCompleteSvcArgs   Pointer to the event completion arguments.
+
+**/
+STATIC
+VOID
+EFIAPI
+DelegatedEventLoop (
+  IN COMM_PROTOCOL                      CommProtocol,
+  IN EDKII_PI_MM_CPU_DRIVER_ENTRYPOINT  CpuDriverEntryPoint,
+  IN ARM_SVC_ARGS                       *EventCompleteSvcArgs
+  )
+{
+  EFI_STATUS    Status;
+  UINT64        Uuid[2];
+  VOID          *CommData;
+  FFA_MSG_INFO  FfaMsgInfo;
+  EFI_GUID      ServiceGuid;
+  SERVICE_TYPE  ServiceType;
+  UINTN         CommBufferAddr;
+
+  CommData = NULL;
+
+  while (TRUE) {
+    // Exit to SPMC.
+    ArmCallSvc (EventCompleteSvcArgs);
+    // Enter from SPMC.
+
+    DEBUG ((DEBUG_INFO, "Received delegated event\n"));
+    DEBUG ((DEBUG_INFO, "X0 :  0x%x\n", (UINT32)EventCompleteSvcArgs->Arg0));
+    DEBUG ((DEBUG_INFO, "X1 :  0x%x\n", (UINT32)EventCompleteSvcArgs->Arg1));
+    DEBUG ((DEBUG_INFO, "X2 :  0x%x\n", (UINT32)EventCompleteSvcArgs->Arg2));
+    DEBUG ((DEBUG_INFO, "X3 :  0x%x\n", (UINT32)EventCompleteSvcArgs->Arg3));
+    DEBUG ((DEBUG_INFO, "X4 :  0x%x\n", (UINT32)EventCompleteSvcArgs->Arg4));
+    DEBUG ((DEBUG_INFO, "X5 :  0x%x\n", (UINT32)EventCompleteSvcArgs->Arg5));
+    DEBUG ((DEBUG_INFO, "X6 :  0x%x\n", (UINT32)EventCompleteSvcArgs->Arg6));
+    DEBUG ((DEBUG_INFO, "X7 :  0x%x\n", (UINT32)EventCompleteSvcArgs->Arg7));
+
+    if (CommProtocol == CommProtocolFfa) {
+      /*
+       * Register Convention for FF-A
+       *   Arg0: ARM_FID_FFA_MSG_SEND_DIRECT_REQ/REQ2
+       *   Arg1: Sender and Receiver endpoint IDs.
+       *   Arg2: Message Flags for ARM_FID_FFA_MSG_SEND_DIRECT_REQ
+       *         Low 8 bytes of UUID for ARM_FID_FFA_MSG_SEND_DIRECT_REQ2
+       *   Arg3: Implementation Defined for ARM_FID_FFA_MSG_SEND_DIRECT_REQ
+       *         High 8 bytes of UUID for ARM_FID_FFA_MSG_SEND_DIRECT_REQ2
+       *   Others: Implementation Defined.
+       *
+       *   See Arm Firmware Framework for Arm A-Profile for detail.
+       */
+      FfaMsgInfo.SourcePartId = GET_SOURCE_PARTITION_ID (EventCompleteSvcArgs->Arg1);
+      FfaMsgInfo.DestPartId   = GET_DEST_PARTITION_ID (EventCompleteSvcArgs->Arg1);
+      CommData                = &FfaMsgInfo;
+
+      if (EventCompleteSvcArgs->Arg0 == ARM_FID_FFA_MSG_SEND_DIRECT_REQ) {
+        FfaMsgInfo.DirectMsgVersion = DirectMsgV1;
+        ServiceType                 = ServiceTypeMmCommunication;
+      } else if (EventCompleteSvcArgs->Arg0 == ARM_FID_FFA_MSG_SEND_DIRECT_REQ2) {
+        FfaMsgInfo.DirectMsgVersion = DirectMsgV2;
+        Uuid[0]                     = EventCompleteSvcArgs->Arg2;
+        Uuid[1]                     = EventCompleteSvcArgs->Arg3;
+        ConvertUuidToEfiGuid (Uuid, &ServiceGuid);
+        ServiceType = GetServiceType (&ServiceGuid);
+      } else {
+        Status = EFI_INVALID_PARAMETER;
+        DEBUG ((
+          DEBUG_ERROR,
+          "Error: Unrecognized FF-A Id: 0x%x\n",
+          EventCompleteSvcArgs->Arg0
+          ));
+        goto ExitHandler;
+      }
+
+      FfaMsgInfo.ServiceType = ServiceType;
+
+      if (ServiceType == ServiceTypeMmCommunication) {
+        if (FfaMsgInfo.DirectMsgVersion == DirectMsgV1) {
+          CommBufferAddr = EventCompleteSvcArgs->Arg3;
+        } else {
+          CommBufferAddr = EventCompleteSvcArgs->Arg4;
+        }
+      } else if (ServiceType == ServiceTypeMisc) {
+        /*
+         * In case of Misc service, generate mm communication header
+         * to dispatch service via StandaloneMmCore.
+         */
+        InitializeMiscMmCommunicateBuffer (
+          EventCompleteSvcArgs,
+          &ServiceGuid,
+          mMiscMmCommunicateBuffer
+          );
+        CommBufferAddr = (UINTN)mMiscMmCommunicateBuffer;
+      } else {
+        Status = EFI_INVALID_PARAMETER;
+        DEBUG ((DEBUG_ERROR, "Error: Invalid FF-A Service...\n"));
+        goto ExitHandler;
+      }
+    } else if (CommProtocol == CommProtocolSpmMm) {
+      /*
+       * Register Convention for SPM_MM
+       *   Arg0: ARM_SMC_ID_MM_COMMUNICATE
+       *   Arg1: Communication Buffer
+       *   Arg2: Size of Communication Buffer
+       *   Arg3: Cpu number where StandaloneMm running on.
+       *
+       *   See tf-a/services/std_svc/spm/spm_mm/spm_mm_main.c
+       */
+      if (EventCompleteSvcArgs->Arg0 != ARM_SMC_ID_MM_COMMUNICATE) {
+        Status = EFI_INVALID_PARAMETER;
+        DEBUG ((
+          DEBUG_ERROR,
+          "Error: Unrecognized SPM_MM Id: 0x%x\n",
+          EventCompleteSvcArgs->Arg0
+          ));
+        goto ExitHandler;
+      }
+
+      CommBufferAddr = EventCompleteSvcArgs->Arg1;
+      ServiceType    = ServiceTypeMmCommunication;
+    }
+
+    if (ServiceType == ServiceTypeMmCommunication) {
+      Status = ValidateMmCommBufferAddr (CommBufferAddr);
+      if (EFI_ERROR (Status)) {
+        DEBUG ((
+          DEBUG_ERROR,
+          "Error: Failed to validate Communication Buffer address(0x%x)...\n",
+          CommBufferAddr
+          ));
+        goto ExitHandler;
+      }
+    }
+
+    Status = CpuDriverEntryPoint ((UINTN)ServiceType, CommBufferAddr);
+    if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "Error: Failed delegated event 0x%x, Status 0x%x\n",
+        CommBufferAddr,
+        Status
+        ));
+    }
+
+ExitHandler:
+    SetEventCompleteSvcArgs (
+      CommProtocol,
+      CommData,
+      Status,
+      EventCompleteSvcArgs
+      );
+  } // while
+}
+
+/**
+  The entry point of Standalone MM Foundation.
+
+  @param  [in]  SharedBufAddress  Pointer to the Buffer between SPM and SP.
+  @param  [in]  SharedBufSize     Size of the shared buffer.
+  @param  [in]  cookie1           Cookie 1
+  @param  [in]  cookie2           Cookie 2
+
+**/
+VOID
+EFIAPI
+_ModuleEntryPoint (
+  IN VOID    *SharedBufAddress,
+  IN UINT64  SharedBufSize,
+  IN UINT64  cookie1,
+  IN UINT64  cookie2
+  )
+{
+  PE_COFF_LOADER_IMAGE_CONTEXT        ImageContext;
+  EFI_SECURE_PARTITION_BOOT_INFO      *PayloadBootInfo;
+  ARM_SVC_ARGS                        EventCompleteSvcArgs;
+  EFI_STATUS                          Status;
+  UINT32                              SectionHeaderOffset;
+  UINT16                              NumberOfSections;
+  COMM_PROTOCOL                       CommProtocol;
+  VOID                                *HobStart;
+  VOID                                *TeData;
+  UINTN                               TeDataSize;
+  EFI_PHYSICAL_ADDRESS                ImageBase;
+  EDKII_PI_MM_CPU_DRIVER_EP_PROTOCOL  *PiMmCpuDriverEpProtocol;
+  EDKII_PI_MM_CPU_DRIVER_ENTRYPOINT   CpuDriverEntryPoint;
+  EFI_HOB_GUID_TYPE                   *GuidHob;
+  EFI_CONFIGURATION_TABLE             *ConfigurationTable;
+  UINTN                               Idx;
+  EFI_MMRAM_HOB_DESCRIPTOR_BLOCK      *MmramRangesHob;
+
+  CpuDriverEntryPoint = NULL;
+
+  Status = GetCommProtocol (&CommProtocol);
+  if (EFI_ERROR (Status)) {
+    goto finish;
+  }
+
+  PayloadBootInfo = GetAndPrintBootinformation (SharedBufAddress);
+  if (PayloadBootInfo == NULL) {
+    Status = EFI_UNSUPPORTED;
+    goto finish;
+  }
+
+  // Locate PE/COFF File information for the Standalone MM core module
+  Status = LocateStandaloneMmCorePeCoffData (
+             (EFI_FIRMWARE_VOLUME_HEADER *)(UINTN)PayloadBootInfo->SpImageBase,
+             &TeData,
+             &TeDataSize
+             );
+
+  if (EFI_ERROR (Status)) {
+    goto finish;
+  }
+
+  // Obtain the PE/COFF Section information for the Standalone MM core module
+  Status = GetStandaloneMmCorePeCoffSections (
+             TeData,
+             &ImageContext,
+             &ImageBase,
+             &SectionHeaderOffset,
+             &NumberOfSections
+             );
+
+  if (EFI_ERROR (Status)) {
+    goto finish;
+  }
+
+  //
+  // ImageBase may deviate from ImageContext.ImageAddress if we are dealing
+  // with a TE image, in which case the latter points to the actual offset
+  // of the image, whereas ImageBase refers to the address where the image
+  // would start if the stripped PE headers were still in place. In either
+  // case, we need to fix up ImageBase so it refers to the actual current
+  // load address.
+  //
+  ImageBase += (UINTN)TeData - ImageContext.ImageAddress;
+
+  // Update the memory access permissions of individual sections in the
+  // Standalone MM core module
+  Status = UpdateMmFoundationPeCoffPermissions (
+             &ImageContext,
+             ImageBase,
+             SectionHeaderOffset,
+             NumberOfSections,
+             ArmSetMemoryRegionNoExec,
+             ArmSetMemoryRegionReadOnly,
+             ArmClearMemoryRegionReadOnly
+             );
+
+  if (EFI_ERROR (Status)) {
+    goto finish;
+  }
+
+  if (ImageContext.ImageAddress != (UINTN)TeData) {
+    ImageContext.ImageAddress = (UINTN)TeData;
+    ArmSetMemoryRegionNoExec (ImageBase, SIZE_4KB);
+    ArmClearMemoryRegionReadOnly (ImageBase, SIZE_4KB);
+
+    Status = PeCoffLoaderRelocateImage (&ImageContext);
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  //
+  // Create Hoblist based upon boot information passed by privileged software
+  //
+  HobStart = CreateHobListFromBootInfo (PayloadBootInfo);
+
+  //
+  // Call the MM Core entry point
+  //
+  ProcessModuleEntryPointList (HobStart);
+
+  // ProcessModuleEntryPointList() copies the HOB List passed
+  // by TF-A, i.e. HobStart, in the ConfigurationTable[].
+  // Therefore, find the HobList in the ConfigurationTable[] by
+  // searching for the gEfiHobListGuid.
+  // Also update the gHobList to point to the HobList in the
+  // ConfigurationTable[] as the HobList passed by TF-A can
+  // be overwritten by StMM after StMM Core is initialised, i.e.
+  // after the MM Core entry point is called.
+  Status             = EFI_NOT_FOUND;
+  ConfigurationTable = gMmCoreMmst.MmConfigurationTable;
+  for (Idx = 0; Idx < gMmCoreMmst.NumberOfTableEntries; Idx++) {
+    if (CompareGuid (&gEfiHobListGuid, &ConfigurationTable[Idx].VendorGuid)) {
+      Status = EFI_SUCCESS;
+      break;
+    }
+  }
+
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "Error: Hoblist not found in MmConfigurationTable\n"));
+    goto finish;
+  }
+
+  gHobList = ConfigurationTable[Idx].VendorTable;
+
+  // Find the descriptor that contains the whereabouts of the buffer for
+  // communication with the Normal world.
+  GuidHob = GetNextGuidHob (&gEfiStandaloneMmNonSecureBufferGuid, gHobList);
+  if (GuidHob == NULL) {
+    Status = EFI_NOT_FOUND;
+    DEBUG ((DEBUG_ERROR, "Error: No NsCommBuffer hob ...\n"));
+    goto finish;
+  }
+
+  mNsCommBuffer = GET_GUID_HOB_DATA (GuidHob);
+  if (mNsCommBuffer == NULL) {
+    Status = EFI_NOT_FOUND;
+    DEBUG ((DEBUG_ERROR, "Error: No NsCommBuffer hob data...\n"));
+    goto finish;
+  }
+
+  //
+  // The base and size of buffer shared with
+  // privileged Secure world software is in PeiMmramMemoryReservedGuid Hob.
+  //
+  GuidHob = GetNextGuidHob (&gEfiMmPeiMmramMemoryReserveGuid, gHobList);
+  if (GuidHob == NULL) {
+    Status = EFI_NOT_FOUND;
+    DEBUG ((DEBUG_ERROR, "Error: No PeiMmramMemoryReserved hob ...\n"));
+    goto finish;
+  }
+
+  MmramRangesHob = GET_GUID_HOB_DATA (GuidHob);
+  if ((MmramRangesHob == NULL) ||
+      (MmramRangesHob->NumberOfMmReservedRegions < MMRAM_DESC_MIN_COUNT))
+  {
+    Status = EFI_NOT_FOUND;
+    DEBUG ((DEBUG_ERROR, "Error: Failed to get shared comm buffer ...\n"));
+    goto finish;
+  }
+
+  mSCommBuffer = &MmramRangesHob->Descriptor[MMRAM_DESC_IDX_SECURE_SHARED_BUFFER];
+
+  //
+  // Find out cpu driver entry point used in DelegatedEventLoop
+  // to handle MMI request.
+  //
+  Status = gMmCoreMmst.MmLocateProtocol (
+                         &gEdkiiPiMmCpuDriverEpProtocolGuid,
+                         NULL,
+                         (VOID **)&PiMmCpuDriverEpProtocol
+                         );
+  if (EFI_ERROR (Status)) {
+    goto finish;
+  }
+
+  CpuDriverEntryPoint = PiMmCpuDriverEpProtocol->PiMmCpuDriverEntryPoint;
+
+  DEBUG ((
+    DEBUG_INFO,
+    "Shared Cpu Driver EP %p\n",
+    CpuDriverEntryPoint
+    ));
+
+  if (CommProtocol == CommProtocolFfa) {
+    Status = gMmCoreMmst.MmAllocatePool (
+                           EfiRuntimeServicesData,
+                           sizeof (MISC_MM_COMMUNICATE_BUFFER),
+                           (VOID **)&mMiscMmCommunicateBuffer
+                           );
+    if (EFI_ERROR (Status)) {
+      DEBUG ((
+        DEBUG_ERROR,
+        "Error: Failed to allocate misc mm communication buffer...\n"
+        ));
+      goto finish;
+    }
+  }
+
+finish:
+  ReturnInitStatusToSpmc (CommProtocol, Status, &EventCompleteSvcArgs);
+
+  // Call DelegateEventLoop(), this function never returns.
+  DelegatedEventLoop (CommProtocol, CpuDriverEntryPoint, &EventCompleteSvcArgs);
+}

--- a/Platforms/QemuSbsaPkg/Override/ArmPkg/Library/StandaloneMmCoreEntryPoint/Arm/StandaloneMmCoreEntryPoint.h
+++ b/Platforms/QemuSbsaPkg/Override/ArmPkg/Library/StandaloneMmCoreEntryPoint/Arm/StandaloneMmCoreEntryPoint.h
@@ -1,0 +1,190 @@
+/** @file
+  Entry point to the Standalone MM Foundation when initialized during the SEC
+  phase on ARM platforms
+
+Copyright (c) 2017 - 2021, Arm Ltd. All rights reserved.<BR>
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef STANDALONEMMCORE_ENTRY_POINT_H_
+#define STANDALONEMMCORE_ENTRY_POINT_H_
+
+#include <Library/PeCoffLib.h>
+#include <Library/FvLib.h>
+
+#define CPU_INFO_FLAG_PRIMARY_CPU  0x00000001
+
+typedef struct {
+  UINT64    Mpidr;
+  UINT32    LinearId;
+  UINT32    Flags;
+} EFI_SECURE_PARTITION_CPU_INFO;
+
+typedef struct {
+  EFI_PARAM_HEADER                 Header;
+  UINT64                           SpMemBase;
+  UINT64                           SpMemLimit;
+  UINT64                           SpImageBase;
+  UINT64                           SpStackBase;
+  UINT64                           SpHeapBase;
+  UINT64                           SpNsCommBufBase;
+  UINT64                           SpSharedBufBase;
+  UINT64                           SpImageSize;
+  UINT64                           SpPcpuStackSize;
+  UINT64                           SpHeapSize;
+  UINT64                           SpNsCommBufSize;
+  UINT64                           SpSharedBufSize;
+  UINT32                           NumSpMemRegions;
+  UINT32                           NumCpus;
+  EFI_SECURE_PARTITION_CPU_INFO    *CpuInfo;
+} EFI_SECURE_PARTITION_BOOT_INFO;
+
+typedef RETURN_STATUS (*REGION_PERMISSION_UPDATE_FUNC) (
+  IN  EFI_PHYSICAL_ADDRESS  BaseAddress,
+  IN  UINT64                Length
+  );
+
+/**
+  Privileged firmware assigns RO & Executable attributes to all memory occupied
+  by the Boot Firmware Volume. This function sets the correct permissions of
+  sections in the Standalone MM Core module to be able to access RO and RW data
+  and make further progress in the boot process.
+
+  @param  [in] ImageContext           Pointer to PE/COFF image context
+  @param  [in] ImageBase              Base of image in memory
+  @param  [in] SectionHeaderOffset    Offset of PE/COFF image section header
+  @param  [in] NumberOfSections       Number of Sections
+  @param  [in] TextUpdater            Function to change code permissions
+  @param  [in] ReadOnlyUpdater        Function to change RO permissions
+  @param  [in] ReadWriteUpdater       Function to change RW permissions
+
+**/
+EFI_STATUS
+EFIAPI
+UpdateMmFoundationPeCoffPermissions (
+  IN  CONST PE_COFF_LOADER_IMAGE_CONTEXT  *ImageContext,
+  IN  EFI_PHYSICAL_ADDRESS                ImageBase,
+  IN  UINT32                              SectionHeaderOffset,
+  IN  CONST  UINT16                       NumberOfSections,
+  IN  REGION_PERMISSION_UPDATE_FUNC       TextUpdater,
+  IN  REGION_PERMISSION_UPDATE_FUNC       ReadOnlyUpdater,
+  IN  REGION_PERMISSION_UPDATE_FUNC       ReadWriteUpdater
+  );
+
+/**
+  Privileged firmware assigns RO & Executable attributes to all memory occupied
+  by the Boot Firmware Volume. This function locates the section information of
+  the Standalone MM Core module to be able to change permissions of the
+  individual sections later in the boot process.
+
+  @param  [in]      TeData                Pointer to PE/COFF image data
+  @param  [in, out] ImageContext          Pointer to PE/COFF image context
+  @param  [out]     ImageBase             Pointer to ImageBase variable
+  @param  [in, out] SectionHeaderOffset   Offset of PE/COFF image section header
+  @param  [in, out] NumberOfSections      Number of Sections
+
+**/
+EFI_STATUS
+EFIAPI
+GetStandaloneMmCorePeCoffSections (
+  IN        VOID                          *TeData,
+  IN  OUT   PE_COFF_LOADER_IMAGE_CONTEXT  *ImageContext,
+  OUT   EFI_PHYSICAL_ADDRESS              *ImageBase,
+  IN  OUT   UINT32                        *SectionHeaderOffset,
+  IN  OUT   UINT16                        *NumberOfSections
+  );
+
+/**
+  Privileged firmware assigns RO & Executable attributes to all memory occupied
+  by the Boot Firmware Volume. This function locates the Standalone MM Core
+  module PE/COFF image in the BFV and returns this information.
+
+  @param  [in]      BfvAddress         Base Address of Boot Firmware Volume
+  @param  [in, out] TeData             Pointer to address for allocating memory
+                                       for PE/COFF image data
+  @param  [in, out] TeDataSize         Pointer to size of PE/COFF image data
+
+**/
+EFI_STATUS
+EFIAPI
+LocateStandaloneMmCorePeCoffData (
+  IN        EFI_FIRMWARE_VOLUME_HEADER  *BfvAddress,
+  IN  OUT   VOID                        **TeData,
+  IN  OUT   UINTN                       *TeDataSize
+  );
+
+/**
+  Use the boot information passed by privileged firmware to populate a HOB list
+  suitable for consumption by the MM Core and drivers.
+
+  @param  [in, out] CpuDriverEntryPoint   Address of MM CPU driver entrypoint
+  @param  [in]      PayloadBootInfo       Boot information passed by privileged
+                                          firmware
+
+**/
+VOID *
+EFIAPI
+CreateHobListFromBootInfo (
+  IN       EFI_SECURE_PARTITION_BOOT_INFO  *PayloadBootInfo
+  );
+
+/**
+  The entry point of Standalone MM Foundation.
+
+  @param  [in]  SharedBufAddress  Pointer to the Buffer between SPM and SP.
+  @param  [in]  SharedBufSize     Size of the shared buffer.
+  @param  [in]  cookie1           Cookie 1
+  @param  [in]  cookie2           Cookie 2
+
+**/
+VOID
+EFIAPI
+_ModuleEntryPoint (
+  IN VOID    *SharedBufAddress,
+  IN UINT64  SharedBufSize,
+  IN UINT64  cookie1,
+  IN UINT64  cookie2
+  );
+
+/**
+  Auto generated function that calls the library constructors for all of the module's dependent libraries.
+
+  This function must be called by _ModuleEntryPoint().
+  This function calls the set of library constructors for the set of library instances
+  that a module depends on.  This includes library instances that a module depends on
+  directly and library instances that a module depends on indirectly through other
+  libraries. This function is auto generated by build tools and those build tools are
+  responsible for collecting the set of library instances, determine which ones have
+  constructors, and calling the library constructors in the proper order based upon
+  each of the library instances own dependencies.
+
+  @param  ImageHandle  The image handle of the DXE Core.
+  @param  SystemTable  A pointer to the EFI System Table.
+
+**/
+VOID
+EFIAPI
+ProcessLibraryConstructorList (
+  IN EFI_HANDLE           ImageHandle,
+  IN EFI_MM_SYSTEM_TABLE  *MmSystemTable
+  );
+
+/**
+  Auto generated function that calls a set of module entry points.
+
+  This function must be called by _ModuleEntryPoint().
+  This function calls the set of module entry points.
+  This function is auto generated by build tools and those build tools are responsible
+  for collecting the module entry points and calling them in a specified order.
+
+  @param  HobStart  Pointer to the beginning of the HOB List passed in from the PEI Phase.
+
+**/
+VOID
+EFIAPI
+ProcessModuleEntryPointList (
+  IN VOID  *HobStart
+  );
+
+#endif

--- a/Platforms/QemuSbsaPkg/Override/ArmPkg/Library/StandaloneMmCoreEntryPoint/StandaloneMmCoreEntryPoint.inf
+++ b/Platforms/QemuSbsaPkg/Override/ArmPkg/Library/StandaloneMmCoreEntryPoint/StandaloneMmCoreEntryPoint.inf
@@ -1,0 +1,74 @@
+## @file
+# Module entry point library for DXE core.
+#
+# Copyright (c) 2017 - 2021, Arm Ltd. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001A
+  # MU_CHANGE [BEGIN]
+  BASE_NAME                      = ArmStandaloneMmCoreEntryPoint
+  FILE_GUID                      = 0D7C6883-E1A8-4A7A-A35C-E0C200775B43
+  # MU_CHANGE [END]
+  MODULE_TYPE                    = MM_CORE_STANDALONE
+  VERSION_STRING                 = 1.0
+  PI_SPECIFICATION_VERSION       = 0x00010032
+  LIBRARY_CLASS                  = StandaloneMmCoreEntryPoint|MM_CORE_STANDALONE
+
+#
+#  VALID_ARCHITECTURES           = IA32 X64 IPF EBC (EBC is for build only)
+#
+
+[Sources.AARCH64, Sources.ARM]
+  Arm/StandaloneMmCoreEntryPoint.c
+  Arm/SetPermissions.c
+  Arm/CreateHobList.c
+  Arm/StandaloneMmCoreEntryPoint.h
+
+# MU_CHANGE [BEGIN]
+# [Sources.X64]
+#   X64/StandaloneMmCoreEntryPoint.c
+# MU_CHANGE [END]
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  StandaloneMmPkg/StandaloneMmPkg.dec
+
+# [Packages.ARM, Packages.AARCH64] # MU_CHANGE: Make StandaloneMmCpu.h available to all archs
+  ArmPkg/ArmPkg.dec
+
+[LibraryClasses]
+  BaseLib
+  DebugLib
+
+[LibraryClasses.ARM, LibraryClasses.AARCH64]
+  # MU_CHANGE [BEGIN] - Nerf StandaloneMmMmuLib. It's just ArmMmuLib.
+  # StandaloneMmMmuLib
+  ArmMmuLib
+  # MU_CHANGE [END] - Nerf StandaloneMmMmuLib. It's just ArmMmuLib.
+  ArmSvcLib
+
+[Guids]
+  gMpInformationHobGuid
+  gEfiMmPeiMmramMemoryReserveGuid
+  gEfiStandaloneMmNonSecureBufferGuid
+  gEfiHobListGuid
+
+[Protocols]
+  gEfiMmCommunication2ProtocolGuid
+  gEdkiiPiMmCpuDriverEpProtocolGuid
+
+#
+# This configuration fails for CLANGPDB, which does not support PIE in the GCC
+# sense. Such however is required for ARM family StandaloneMmCore
+# self-relocation, and thus the CLANGPDB toolchain is unsupported for ARM and
+# AARCH64 for this module.
+#
+[BuildOptions]
+  GCC:*_*_ARM_CC_FLAGS = -fpie
+  GCC:*_*_AARCH64_CC_FLAGS = -fpie

--- a/Platforms/QemuSbsaPkg/Override/StandaloneMmPkg/Library/StandaloneMmCoreHobLib/Arm/StandaloneMmCoreHobLib.c
+++ b/Platforms/QemuSbsaPkg/Override/StandaloneMmPkg/Library/StandaloneMmCoreHobLib/Arm/StandaloneMmCoreHobLib.c
@@ -1,0 +1,366 @@
+/** @file
+  HOB Library implementation for Standalone MM Core.
+
+Copyright (c) 2006 - 2014, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2017 - 2018, ARM Limited. All rights reserved.<BR>
+
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiMm.h>
+
+#include <Library/HobLib.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseMemoryLib.h>
+
+#include <Guid/MemoryAllocationHob.h>
+
+//
+// Cache copy of HobList pointer.
+//
+VOID  *gHobList = NULL;
+
+VOID *
+CreateHob (
+  IN  UINT16  HobType,
+  IN  UINT16  HobLength
+  )
+{
+  EFI_HOB_HANDOFF_INFO_TABLE  *HandOffHob;
+  EFI_HOB_GENERIC_HEADER      *HobEnd;
+  EFI_PHYSICAL_ADDRESS        FreeMemory;
+  VOID                        *Hob;
+
+  HandOffHob = GetHobList ();
+
+  //
+  // Check Length to avoid data overflow.
+  //
+  if (HobLength > MAX_UINT16 - 0x7) {
+    return NULL;
+  }
+
+  HobLength = (UINT16)((HobLength + 0x7) & (~0x7));
+
+  FreeMemory = HandOffHob->EfiFreeMemoryTop - HandOffHob->EfiFreeMemoryBottom;
+
+  if (FreeMemory < HobLength) {
+    return NULL;
+  }
+
+  Hob                                        = (VOID *)(UINTN)HandOffHob->EfiEndOfHobList;
+  ((EFI_HOB_GENERIC_HEADER *)Hob)->HobType   = HobType;
+  ((EFI_HOB_GENERIC_HEADER *)Hob)->HobLength = HobLength;
+  ((EFI_HOB_GENERIC_HEADER *)Hob)->Reserved  = 0;
+
+  HobEnd                      = (EFI_HOB_GENERIC_HEADER *)((UINTN)Hob + HobLength);
+  HandOffHob->EfiEndOfHobList = (EFI_PHYSICAL_ADDRESS)(UINTN)HobEnd;
+
+  HobEnd->HobType   = EFI_HOB_TYPE_END_OF_HOB_LIST;
+  HobEnd->HobLength = sizeof (EFI_HOB_GENERIC_HEADER);
+  HobEnd->Reserved  = 0;
+  HobEnd++;
+  HandOffHob->EfiFreeMemoryBottom = (EFI_PHYSICAL_ADDRESS)(UINTN)HobEnd;
+
+  return Hob;
+}
+
+/**
+  Builds a HOB for a loaded PE32 module.
+
+  This function builds a HOB for a loaded PE32 module.
+  If ModuleName is NULL, then ASSERT().
+  If there is no additional space for HOB creation, then ASSERT().
+
+  @param  ModuleName              The GUID File Name of the module.
+  @param  MemoryAllocationModule  The 64 bit physical address of the module.
+  @param  ModuleLength            The length of the module in bytes.
+  @param  EntryPoint              The 64 bit physical address of the module entry point.
+
+**/
+VOID
+EFIAPI
+BuildModuleHob (
+  IN CONST EFI_GUID        *ModuleName,
+  IN EFI_PHYSICAL_ADDRESS  MemoryAllocationModule,
+  IN UINT64                ModuleLength,
+  IN EFI_PHYSICAL_ADDRESS  EntryPoint
+  )
+{
+  EFI_HOB_MEMORY_ALLOCATION_MODULE  *Hob;
+
+  ASSERT (
+    ((MemoryAllocationModule & (EFI_PAGE_SIZE - 1)) == 0) &&
+    ((ModuleLength & (EFI_PAGE_SIZE - 1)) == 0)
+    );
+
+  Hob = CreateHob (EFI_HOB_TYPE_MEMORY_ALLOCATION, sizeof (EFI_HOB_MEMORY_ALLOCATION_MODULE));
+  ASSERT (Hob != NULL);
+  if (Hob == NULL) {
+    return;
+  }
+
+  CopyGuid (&(Hob->MemoryAllocationHeader.Name), &gEfiHobMemoryAllocModuleGuid);
+  Hob->MemoryAllocationHeader.MemoryBaseAddress = MemoryAllocationModule;
+  Hob->MemoryAllocationHeader.MemoryLength      = ModuleLength;
+  Hob->MemoryAllocationHeader.MemoryType        = EfiBootServicesCode;
+
+  //
+  // Zero the reserved space to match HOB spec
+  //
+  ZeroMem (Hob->MemoryAllocationHeader.Reserved, sizeof (Hob->MemoryAllocationHeader.Reserved));
+
+  CopyGuid (&Hob->ModuleName, ModuleName);
+  Hob->EntryPoint = EntryPoint;
+}
+
+/**
+  Builds a HOB that describes a chunk of system memory.
+
+  This function builds a HOB that describes a chunk of system memory.
+  If there is no additional space for HOB creation, then ASSERT().
+
+  @param  ResourceType        The type of resource described by this HOB.
+  @param  ResourceAttribute   The resource attributes of the memory described by this HOB.
+  @param  PhysicalStart       The 64 bit physical address of memory described by this HOB.
+  @param  NumberOfBytes       The length of the memory described by this HOB in bytes.
+
+**/
+VOID
+EFIAPI
+BuildResourceDescriptorHob (
+  IN EFI_RESOURCE_TYPE            ResourceType,
+  IN EFI_RESOURCE_ATTRIBUTE_TYPE  ResourceAttribute,
+  IN EFI_PHYSICAL_ADDRESS         PhysicalStart,
+  IN UINT64                       NumberOfBytes
+  )
+{
+  EFI_HOB_RESOURCE_DESCRIPTOR  *Hob;
+
+  Hob = CreateHob (EFI_HOB_TYPE_RESOURCE_DESCRIPTOR, sizeof (EFI_HOB_RESOURCE_DESCRIPTOR));
+  ASSERT (Hob != NULL);
+  if (Hob == NULL) {
+    return;
+  }
+
+  Hob->ResourceType      = ResourceType;
+  Hob->ResourceAttribute = ResourceAttribute;
+  Hob->PhysicalStart     = PhysicalStart;
+  Hob->ResourceLength    = NumberOfBytes;
+}
+
+/**
+  Builds a GUID HOB with a certain data length.
+
+  This function builds a customized HOB tagged with a GUID for identification
+  and returns the start address of GUID HOB data so that caller can fill the customized data.
+  The HOB Header and Name field is already stripped.
+  If Guid is NULL, then ASSERT().
+  If there is no additional space for HOB creation, then ASSERT().
+  If DataLength >= (0x10000 - sizeof (EFI_HOB_GUID_TYPE)), then ASSERT().
+
+  @param  Guid          The GUID to tag the customized HOB.
+  @param  DataLength    The size of the data payload for the GUID HOB.
+
+  @return The start address of GUID HOB data.
+
+**/
+VOID *
+EFIAPI
+BuildGuidHob (
+  IN CONST EFI_GUID  *Guid,
+  IN UINTN           DataLength
+  )
+{
+  EFI_HOB_GUID_TYPE  *Hob;
+
+  //
+  // Make sure that data length is not too long.
+  //
+  ASSERT (DataLength <= (0xffff - sizeof (EFI_HOB_GUID_TYPE)));
+
+  Hob = CreateHob (EFI_HOB_TYPE_GUID_EXTENSION, (UINT16)(sizeof (EFI_HOB_GUID_TYPE) + DataLength));
+  ASSERT (Hob != NULL);
+  if (Hob == NULL) {
+    return NULL;
+  }
+
+  CopyGuid (&Hob->Name, Guid);
+  return Hob + 1;
+}
+
+/**
+  Copies a data buffer to a newly-built HOB.
+
+  This function builds a customized HOB tagged with a GUID for identification,
+  copies the input data to the HOB data field and returns the start address of the GUID HOB data.
+  The HOB Header and Name field is already stripped.
+  If Guid is NULL, then ASSERT().
+  If Data is NULL and DataLength > 0, then ASSERT().
+  If there is no additional space for HOB creation, then ASSERT().
+  If DataLength >= (0x10000 - sizeof (EFI_HOB_GUID_TYPE)), then ASSERT().
+
+  @param  Guid          The GUID to tag the customized HOB.
+  @param  Data          The data to be copied into the data field of the GUID HOB.
+  @param  DataLength    The size of the data payload for the GUID HOB.
+
+  @return The start address of GUID HOB data.
+
+**/
+VOID *
+EFIAPI
+BuildGuidDataHob (
+  IN CONST EFI_GUID  *Guid,
+  IN VOID            *Data,
+  IN UINTN           DataLength
+  )
+{
+  VOID  *HobData;
+
+  ASSERT (Data != NULL || DataLength == 0);
+
+  HobData = BuildGuidHob (Guid, DataLength);
+
+  return CopyMem (HobData, Data, DataLength);
+}
+
+/**
+  Builds a Firmware Volume HOB.
+
+  This function builds a Firmware Volume HOB.
+  If there is no additional space for HOB creation, then ASSERT().
+
+  @param  BaseAddress   The base address of the Firmware Volume.
+  @param  Length        The size of the Firmware Volume in bytes.
+
+**/
+VOID
+EFIAPI
+BuildFvHob (
+  IN EFI_PHYSICAL_ADDRESS  BaseAddress,
+  IN UINT64                Length
+  )
+{
+  EFI_HOB_FIRMWARE_VOLUME  *Hob;
+
+  Hob = CreateHob (EFI_HOB_TYPE_FV, sizeof (EFI_HOB_FIRMWARE_VOLUME));
+  ASSERT (Hob != NULL);
+  if (Hob == NULL) {
+    return;
+  }
+
+  Hob->BaseAddress = BaseAddress;
+  Hob->Length      = Length;
+}
+
+/**
+  Builds a EFI_HOB_TYPE_FV2 HOB.
+
+  This function builds a EFI_HOB_TYPE_FV2 HOB.
+  If there is no additional space for HOB creation, then ASSERT().
+
+  @param  BaseAddress   The base address of the Firmware Volume.
+  @param  Length        The size of the Firmware Volume in bytes.
+  @param  FvName       The name of the Firmware Volume.
+  @param  FileName      The name of the file.
+
+**/
+VOID
+EFIAPI
+BuildFv2Hob (
+  IN          EFI_PHYSICAL_ADDRESS  BaseAddress,
+  IN          UINT64                Length,
+  IN CONST    EFI_GUID              *FvName,
+  IN CONST    EFI_GUID              *FileName
+  )
+{
+  EFI_HOB_FIRMWARE_VOLUME2  *Hob;
+
+  Hob = CreateHob (EFI_HOB_TYPE_FV2, sizeof (EFI_HOB_FIRMWARE_VOLUME2));
+  ASSERT (Hob != NULL);
+  if (Hob == NULL) {
+    return;
+  }
+
+  Hob->BaseAddress = BaseAddress;
+  Hob->Length      = Length;
+  CopyGuid (&Hob->FvName, FvName);
+  CopyGuid (&Hob->FileName, FileName);
+}
+
+/**
+  Builds a HOB for the CPU.
+
+  This function builds a HOB for the CPU.
+  If there is no additional space for HOB creation, then ASSERT().
+
+  @param  SizeOfMemorySpace   The maximum physical memory addressability of the processor.
+  @param  SizeOfIoSpace       The maximum physical I/O addressability of the processor.
+
+**/
+VOID
+EFIAPI
+BuildCpuHob (
+  IN UINT8  SizeOfMemorySpace,
+  IN UINT8  SizeOfIoSpace
+  )
+{
+  EFI_HOB_CPU  *Hob;
+
+  Hob = CreateHob (EFI_HOB_TYPE_CPU, sizeof (EFI_HOB_CPU));
+  ASSERT (Hob != NULL);
+  if (Hob == NULL) {
+    return;
+  }
+
+  Hob->SizeOfMemorySpace = SizeOfMemorySpace;
+  Hob->SizeOfIoSpace     = SizeOfIoSpace;
+
+  //
+  // Zero the reserved space to match HOB spec
+  //
+  ZeroMem (Hob->Reserved, sizeof (Hob->Reserved));
+}
+
+/**
+  Builds a HOB for the memory allocation.
+
+  This function builds a HOB for the memory allocation.
+  If there is no additional space for HOB creation, then ASSERT().
+
+  @param  BaseAddress   The 64 bit physical address of the memory.
+  @param  Length        The length of the memory allocation in bytes.
+  @param  MemoryType    Type of memory allocated by this HOB.
+
+**/
+VOID
+EFIAPI
+BuildMemoryAllocationHob (
+  IN EFI_PHYSICAL_ADDRESS  BaseAddress,
+  IN UINT64                Length,
+  IN EFI_MEMORY_TYPE       MemoryType
+  )
+{
+  EFI_HOB_MEMORY_ALLOCATION  *Hob;
+
+  ASSERT (
+    ((BaseAddress & (EFI_PAGE_SIZE - 1)) == 0) &&
+    ((Length & (EFI_PAGE_SIZE - 1)) == 0)
+    );
+
+  Hob = CreateHob (EFI_HOB_TYPE_MEMORY_ALLOCATION, sizeof (EFI_HOB_MEMORY_ALLOCATION));
+  ASSERT (Hob != NULL);
+  if (Hob == NULL) {
+    return;
+  }
+
+  ZeroMem (&(Hob->AllocDescriptor.Name), sizeof (EFI_GUID));
+  Hob->AllocDescriptor.MemoryBaseAddress = BaseAddress;
+  Hob->AllocDescriptor.MemoryLength      = Length;
+  Hob->AllocDescriptor.MemoryType        = MemoryType;
+  //
+  // Zero the reserved space to match HOB spec
+  //
+  ZeroMem (Hob->AllocDescriptor.Reserved, sizeof (Hob->AllocDescriptor.Reserved));
+}

--- a/Platforms/QemuSbsaPkg/Override/StandaloneMmPkg/Library/StandaloneMmCoreHobLib/Arm/StandaloneMmCoreHobLibInternal.c
+++ b/Platforms/QemuSbsaPkg/Override/StandaloneMmPkg/Library/StandaloneMmCoreHobLib/Arm/StandaloneMmCoreHobLibInternal.c
@@ -1,0 +1,58 @@
+/** @file
+  HOB Library implementation for Standalone MM Core.
+
+Copyright (c) 2006 - 2014, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2017 - 2018, ARM Limited. All rights reserved.<BR>
+
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiMm.h>
+
+#include <Library/HobLib.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseMemoryLib.h>
+
+#include <Guid/MemoryAllocationHob.h>
+
+//
+// Cache copy of HobList pointer.
+//
+extern VOID  *gHobList;
+
+EFI_HOB_HANDOFF_INFO_TABLE *
+HobConstructor (
+  IN VOID   *EfiMemoryBegin,
+  IN UINTN  EfiMemoryLength,
+  IN VOID   *EfiFreeMemoryBottom,
+  IN VOID   *EfiFreeMemoryTop
+  )
+{
+  EFI_HOB_HANDOFF_INFO_TABLE  *Hob;
+  EFI_HOB_GENERIC_HEADER      *HobEnd;
+
+  Hob    = EfiFreeMemoryBottom;
+  HobEnd = (EFI_HOB_GENERIC_HEADER *)(Hob+1);
+
+  Hob->Header.HobType   = EFI_HOB_TYPE_HANDOFF;
+  Hob->Header.HobLength = sizeof (EFI_HOB_HANDOFF_INFO_TABLE);
+  Hob->Header.Reserved  = 0;
+
+  HobEnd->HobType   = EFI_HOB_TYPE_END_OF_HOB_LIST;
+  HobEnd->HobLength = sizeof (EFI_HOB_GENERIC_HEADER);
+  HobEnd->Reserved  = 0;
+
+  Hob->Version  = EFI_HOB_HANDOFF_TABLE_VERSION;
+  Hob->BootMode = BOOT_WITH_FULL_CONFIGURATION;
+
+  Hob->EfiMemoryTop        = (UINTN)EfiMemoryBegin + EfiMemoryLength;
+  Hob->EfiMemoryBottom     = (UINTN)EfiMemoryBegin;
+  Hob->EfiFreeMemoryTop    = (UINTN)EfiFreeMemoryTop;
+  Hob->EfiFreeMemoryBottom = (EFI_PHYSICAL_ADDRESS)(UINTN)(HobEnd+1);
+  Hob->EfiEndOfHobList     = (EFI_PHYSICAL_ADDRESS)(UINTN)HobEnd;
+
+  gHobList = Hob;
+
+  return Hob;
+}

--- a/Platforms/QemuSbsaPkg/Override/StandaloneMmPkg/Library/StandaloneMmCoreHobLib/Common.c
+++ b/Platforms/QemuSbsaPkg/Override/StandaloneMmPkg/Library/StandaloneMmCoreHobLib/Common.c
@@ -1,0 +1,293 @@
+/** @file
+  HOB Library implementation for Standalone MM Core.
+
+Copyright (c) 2006 - 2014, Intel Corporation. All rights reserved.<BR>
+Copyright (c) 2017 - 2018, ARM Limited. All rights reserved.<BR>
+
+SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#include <PiMm.h>
+
+#include <Library/HobLib.h>
+#include <Library/DebugLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/StandaloneMmCoreEntryPoint.h>
+
+#include <Guid/MemoryAllocationHob.h>
+
+/**
+  Returns the pointer to the HOB list.
+
+  This function returns the pointer to first HOB in the list.
+  If the pointer to the HOB list is NULL, then ASSERT().
+
+  @return The pointer to the HOB list.
+
+**/
+VOID *
+EFIAPI
+GetHobList (
+  VOID
+  )
+{
+  ASSERT (gHobList != NULL);
+  return gHobList;
+}
+
+/**
+  Returns the next instance of a HOB type from the starting HOB.
+
+  This function searches the first instance of a HOB type from the starting HOB pointer.
+  If there does not exist such HOB type from the starting HOB pointer, it will return NULL.
+  In contrast with macro GET_NEXT_HOB(), this function does not skip the starting HOB pointer
+  unconditionally: it returns HobStart back if HobStart itself meets the requirement;
+  caller is required to use GET_NEXT_HOB() if it wishes to skip current HobStart.
+
+  If HobStart is NULL, then ASSERT().
+
+  @param  Type          The HOB type to return.
+  @param  HobStart      The starting HOB pointer to search from.
+
+  @return The next instance of a HOB type from the starting HOB.
+
+**/
+VOID *
+EFIAPI
+GetNextHob (
+  IN UINT16      Type,
+  IN CONST VOID  *HobStart
+  )
+{
+  EFI_PEI_HOB_POINTERS  Hob;
+
+  ASSERT (HobStart != NULL);
+
+  Hob.Raw = (UINT8 *)HobStart;
+  //
+  // Parse the HOB list until end of list or matching type is found.
+  //
+  while (!END_OF_HOB_LIST (Hob)) {
+    if (Hob.Header->HobType == Type) {
+      return Hob.Raw;
+    }
+
+    Hob.Raw = GET_NEXT_HOB (Hob);
+  }
+
+  return NULL;
+}
+
+/**
+  Returns the first instance of a HOB type among the whole HOB list.
+
+  This function searches the first instance of a HOB type among the whole HOB list.
+  If there does not exist such HOB type in the HOB list, it will return NULL.
+
+  If the pointer to the HOB list is NULL, then ASSERT().
+
+  @param  Type          The HOB type to return.
+
+  @return The next instance of a HOB type from the starting HOB.
+
+**/
+VOID *
+EFIAPI
+GetFirstHob (
+  IN UINT16  Type
+  )
+{
+  VOID  *HobList;
+
+  HobList = GetHobList ();
+  return GetNextHob (Type, HobList);
+}
+
+/**
+  Returns the next instance of the matched GUID HOB from the starting HOB.
+
+  This function searches the first instance of a HOB from the starting HOB pointer.
+  Such HOB should satisfy two conditions:
+  its HOB type is EFI_HOB_TYPE_GUID_EXTENSION, and its GUID Name equals to the input Guid.
+  If such a HOB from the starting HOB pointer does not exist, it will return NULL.
+  Caller is required to apply GET_GUID_HOB_DATA () and GET_GUID_HOB_DATA_SIZE ()
+  to extract the data section and its size information, respectively.
+  In contrast with macro GET_NEXT_HOB(), this function does not skip the starting HOB pointer
+  unconditionally: it returns HobStart back if HobStart itself meets the requirement;
+  caller is required to use GET_NEXT_HOB() if it wishes to skip current HobStart.
+
+  If Guid is NULL, then ASSERT().
+  If HobStart is NULL, then ASSERT().
+
+  @param  Guid          The GUID to match with in the HOB list.
+  @param  HobStart      A pointer to a Guid.
+
+  @return The next instance of the matched GUID HOB from the starting HOB.
+
+**/
+VOID *
+EFIAPI
+GetNextGuidHob (
+  IN CONST EFI_GUID  *Guid,
+  IN CONST VOID      *HobStart
+  )
+{
+  EFI_PEI_HOB_POINTERS  GuidHob;
+
+  GuidHob.Raw = (UINT8 *)HobStart;
+  while ((GuidHob.Raw = GetNextHob (EFI_HOB_TYPE_GUID_EXTENSION, GuidHob.Raw)) != NULL) {
+    if (CompareGuid (Guid, &GuidHob.Guid->Name)) {
+      break;
+    }
+
+    GuidHob.Raw = GET_NEXT_HOB (GuidHob);
+  }
+
+  return GuidHob.Raw;
+}
+
+/**
+  Returns the first instance of the matched GUID HOB among the whole HOB list.
+
+  This function searches the first instance of a HOB among the whole HOB list.
+  Such HOB should satisfy two conditions:
+  its HOB type is EFI_HOB_TYPE_GUID_EXTENSION and its GUID Name equals to the input Guid.
+  If such a HOB from the starting HOB pointer does not exist, it will return NULL.
+  Caller is required to apply GET_GUID_HOB_DATA () and GET_GUID_HOB_DATA_SIZE ()
+  to extract the data section and its size information, respectively.
+
+  If the pointer to the HOB list is NULL, then ASSERT().
+  If Guid is NULL, then ASSERT().
+
+  @param  Guid          The GUID to match with in the HOB list.
+
+  @return The first instance of the matched GUID HOB among the whole HOB list.
+
+**/
+VOID *
+EFIAPI
+GetFirstGuidHob (
+  IN CONST EFI_GUID  *Guid
+  )
+{
+  VOID  *HobList;
+
+  HobList = GetHobList ();
+  return GetNextGuidHob (Guid, HobList);
+}
+
+/**
+  Get the system boot mode from the HOB list.
+
+  This function returns the system boot mode information from the
+  PHIT HOB in HOB list.
+
+  If the pointer to the HOB list is NULL, then ASSERT().
+
+  @param  VOID
+
+  @return The Boot Mode.
+
+**/
+EFI_BOOT_MODE
+EFIAPI
+GetBootModeHob (
+  VOID
+  )
+{
+  EFI_HOB_HANDOFF_INFO_TABLE  *HandOffHob;
+
+  HandOffHob = (EFI_HOB_HANDOFF_INFO_TABLE *)GetHobList ();
+
+  return HandOffHob->BootMode;
+}
+
+/**
+  Builds a HOB that describes a chunk of system memory with Owner GUID.
+
+  This function builds a HOB that describes a chunk of system memory.
+  If there is no additional space for HOB creation, then ASSERT().
+
+  @param  ResourceType        The type of resource described by this HOB.
+  @param  ResourceAttribute   The resource attributes of the memory described by this HOB.
+  @param  PhysicalStart       The 64 bit physical address of memory described by this HOB.
+  @param  NumberOfBytes       The length of the memory described by this HOB in bytes.
+  @param  OwnerGUID           GUID for the owner of this resource.
+
+**/
+VOID
+EFIAPI
+BuildResourceDescriptorWithOwnerHob (
+  IN EFI_RESOURCE_TYPE            ResourceType,
+  IN EFI_RESOURCE_ATTRIBUTE_TYPE  ResourceAttribute,
+  IN EFI_PHYSICAL_ADDRESS         PhysicalStart,
+  IN UINT64                       NumberOfBytes,
+  IN EFI_GUID                     *OwnerGUID
+  )
+{
+  ASSERT (FALSE);
+}
+
+/**
+  Builds a Capsule Volume HOB.
+
+  This function builds a Capsule Volume HOB.
+  If the platform does not support Capsule Volume HOBs, then ASSERT().
+  If there is no additional space for HOB creation, then ASSERT().
+
+  @param  BaseAddress   The base address of the Capsule Volume.
+  @param  Length        The size of the Capsule Volume in bytes.
+
+**/
+VOID
+EFIAPI
+BuildCvHob (
+  IN EFI_PHYSICAL_ADDRESS  BaseAddress,
+  IN UINT64                Length
+  )
+{
+  ASSERT (FALSE);
+}
+
+/**
+  Builds a HOB for the BSP store.
+
+  This function builds a HOB for BSP store.
+  If there is no additional space for HOB creation, then ASSERT().
+
+  @param  BaseAddress   The 64 bit physical address of the BSP.
+  @param  Length        The length of the BSP store in bytes.
+  @param  MemoryType    Type of memory allocated by this HOB.
+
+**/
+VOID
+EFIAPI
+BuildBspStoreHob (
+  IN EFI_PHYSICAL_ADDRESS  BaseAddress,
+  IN UINT64                Length,
+  IN EFI_MEMORY_TYPE       MemoryType
+  )
+{
+  ASSERT (FALSE);
+}
+
+/**
+  Builds a HOB for the Stack.
+
+  This function builds a HOB for the stack.
+  If there is no additional space for HOB creation, then ASSERT().
+
+  @param  BaseAddress   The 64 bit physical address of the Stack.
+  @param  Length        The length of the stack in bytes.
+
+**/
+VOID
+EFIAPI
+BuildStackHob (
+  IN EFI_PHYSICAL_ADDRESS  BaseAddress,
+  IN UINT64                Length
+  )
+{
+  ASSERT (FALSE);
+}

--- a/Platforms/QemuSbsaPkg/Override/StandaloneMmPkg/Library/StandaloneMmCoreHobLib/StandaloneMmCoreHobLib.inf
+++ b/Platforms/QemuSbsaPkg/Override/StandaloneMmPkg/Library/StandaloneMmCoreHobLib/StandaloneMmCoreHobLib.inf
@@ -1,0 +1,47 @@
+## @file
+# Instance of HOB Library for Standalone MM Core.
+#
+# HOB Library implementation for the Standalone MM Core. Does not have a constructor.
+#  Uses gHobList defined in the Standalone MM Core Entry Point Library.
+#
+# Copyright (c) 2007 - 2014, Intel Corporation. All rights reserved.<BR>
+# Copyright (c) 2016 - 2018, ARM Limited. All rights reserved.<BR>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001A
+  BASE_NAME                      = HobLib
+  FILE_GUID                      = CF56EF2C-68D8-4BD5-9A8B-8A7BFCFF751C
+  MODULE_TYPE                    = MM_CORE_STANDALONE
+  VERSION_STRING                 = 1.0
+  PI_SPECIFICATION_VERSION       = 0x00010032
+  LIBRARY_CLASS                  = HobLib|MM_CORE_STANDALONE
+
+#
+#  VALID_ARCHITECTURES           = X64 AARCH64 ARM
+#
+[Sources.common]
+  Common.c
+
+[Sources.X64]
+  X64/StandaloneMmCoreHobLib.c
+
+[Sources.AARCH64, Sources.ARM]
+  Arm/StandaloneMmCoreHobLib.c
+  Arm/StandaloneMmCoreHobLibInternal.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  StandaloneMmPkg/StandaloneMmPkg.dec
+
+
+[LibraryClasses]
+  BaseMemoryLib
+  DebugLib
+
+[Guids]
+  gEfiHobListGuid                               ## CONSUMES  ## SystemTable

--- a/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
+++ b/Platforms/QemuSbsaPkg/QemuSbsaPkg.dsc
@@ -487,14 +487,14 @@
   BaseMemoryLib|MdePkg/Library/BaseMemoryLib/BaseMemoryLib.inf
   ExtractGuidedSectionLib|EmbeddedPkg/Library/PrePiExtractGuidedSectionLib/PrePiExtractGuidedSectionLib.inf
   FvLib|StandaloneMmPkg/Library/FvLib/FvLib.inf
-  HobLib|StandaloneMmPkg/Library/StandaloneMmCoreHobLib/StandaloneMmCoreHobLib.inf
+  HobLib|QemuSbsaPkg/Override/StandaloneMmPkg/Library/StandaloneMmCoreHobLib/StandaloneMmCoreHobLib.inf
   IoLib|MdePkg/Library/BaseIoLibIntrinsic/BaseIoLibIntrinsic.inf
   MemoryAllocationLib|StandaloneMmPkg/Library/StandaloneMmCoreMemoryAllocationLib/StandaloneMmCoreMemoryAllocationLib.inf
   PcdLib|MdePkg/Library/BasePcdLibNull/BasePcdLibNull.inf
 
   ArmMmuLib|ArmPkg/Library/StandaloneMmMmuLib/ArmMmuStandaloneMmLib.inf
   ArmFfaLib|ArmPkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf
-  StandaloneMmCoreEntryPoint|ArmPkg/Library/ArmStandaloneMmCoreEntryPoint/ArmStandaloneMmCoreEntryPoint.inf
+  StandaloneMmCoreEntryPoint|QemuSbsaPkg/Override/ArmPkg/Library/StandaloneMmCoreEntryPoint/StandaloneMmCoreEntryPoint.inf
   PeCoffExtraActionLib|StandaloneMmPkg/Library/StandaloneMmPeCoffExtraActionLib/StandaloneMmPeCoffExtraActionLib.inf
   MmServicesTableLib|StandaloneMmPkg/Library/StandaloneMmServicesTableLib/StandaloneMmServicesTableLibCore.inf
 
@@ -606,6 +606,9 @@
   # ASSERT_BREAKPOINT_ENABLED  0x10
   # ASSERT_DEADLOOP_ENABLED    0x20
   gEfiMdePkgTokenSpaceGuid.PcdDebugPropertyMask|0x17
+
+  # Set to TRUE to enable the use of the Arm FFA Conduit SMC for non-MM modules
+  gArmTokenSpaceGuid.PcdFfaLibConduitSmc|TRUE
 
 [PcdsFixedAtBuild.common]
   !include QemuPkg/AutoGen/SecurebootPcds.inc
@@ -1402,6 +1405,8 @@
   StandaloneMmPkg/Core/StandaloneMmCore.inf {
     <PcdsFixedAtBuild>
       gEfiMdePkgTokenSpaceGuid.PcdDebugPrintErrorLevel|0x80000000
+    <PcdsPatchableInModule>
+      gArmTokenSpaceGuid.PcdFfaLibConduitSmc|FALSE
   }
 
   ArmPkg/Drivers/StandaloneMmCpu/StandaloneMmCpu.inf {


### PR DESCRIPTION
## Description

Because the TFA change is not fully ready, we will need to override the HobLib and StandaloneMmEntrypoint library to not rely on TFA creating the hobs.

For reference, the TFA PR is here:
https://review.trustedfirmware.org/c/TF-A/trusted-firmware-a/+/35001

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

This is tested with QEMU SBSA and booted to Windows.

## Integration Instructions

N/A